### PR TITLE
#879: contentLinkPlugin now fetches taxonomy

### DIFF
--- a/src/__tests__/__snapshots__/replacer-test.js.snap
+++ b/src/__tests__/__snapshots__/replacer-test.js.snap
@@ -2193,7 +2193,5 @@ exports[`replacer/replaceEmbedsInHtml replace various emdeds in html 1`] = `
     </div>
   </figure>
   <p>SomeText3</p>
-  <a href=\\"https://ndla-frontend.test.api.ndla.no/nb/article/425\\">Valg av informanter
-  </a>
 </section>"
 `;

--- a/src/__tests__/replacer-test.js
+++ b/src/__tests__/replacer-test.js
@@ -11,7 +11,6 @@ import { prettify } from './testHelpers';
 import { replaceEmbedsInHtml } from '../replacer';
 import getEmbedMetaData from '../getEmbedMetaData';
 import {
-  createContentLinkPlugin,
   createH5pPlugin,
   createImagePlugin,
   createBrightcovePlugin,
@@ -34,16 +33,10 @@ test('replacer/replaceEmbedsInHtml replace various emdeds in html', async () => 
     <section>
       <embed data-resource="brightcove" data-id="2" data-videoid="ref:46012" data-account="4806596774001" data-player="BkLm8fT"/>
       <p>SomeText3</p>
-      <embed data-resource="content-link" data-id="1" data-content-id="425" data-link-text="Valg av informanter"/>
     </section>`
   );
 
   const embeds = [
-    {
-      embed: articleContent('embed[data-resource="content-link"]'),
-      data: articleContent('embed[data-resource="content-link"]').data(),
-      plugin: createContentLinkPlugin(),
-    },
     {
       embed: articleContent('embed[data-resource="h5p"]'),
       data: articleContent('embed[data-resource="h5p"]').data(),

--- a/src/plugins/__tests__/__snapshots__/contentLinkPlugin-test.js.snap
+++ b/src/plugins/__tests__/__snapshots__/contentLinkPlugin-test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`embedToHtml should return anchor tag with path 1`] = `"<a href=\\"https://ndla-frontend.test.api.ndla.no/nb/urn:test:1\\">text</a>"`;
+
+exports[`fetchResource for content-link 1`] = `
+Object {
+  "data": Object {
+    "contentId": "1",
+  },
+  "path": "article/urn:subject:12/urn:topic:1:183846/urn:topic:1:183935/urn:resource:1:110269/1",
+}
+`;

--- a/src/plugins/__tests__/contentLinkPlugin-test.js
+++ b/src/plugins/__tests__/contentLinkPlugin-test.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2018-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import nock from 'nock';
+import bunyan from 'bunyan';
+import log from '../../utils/logger';
+import createContentLinkPlugin from '../contentLinkPlugin';
+
+const articleResource = [
+  {
+    resourceTypes: [
+      {
+        id: 'urn:resourcetype:tasksAndActivities',
+        name: 'Oppgaver og aktiviteter',
+      },
+    ],
+    path: '/subject:12/topic:1:183846/topic:1:183935/resource:1:110269',
+  },
+];
+
+test('fetchResource for content-link', async () => {
+  const contentLinkPlugin = createContentLinkPlugin();
+
+  nock('https://test.api.ndla.no')
+    .get(`/taxonomy/v1/queries/resources?contentURI=urn:article:1`)
+    .reply(200, articleResource);
+
+  const resource = await contentLinkPlugin.fetchResource({
+    data: { contentId: '1' },
+  });
+
+  expect(resource).toMatchSnapshot();
+});
+
+test('fetchResource where taxonomy fails should fallback to path without taxonomy', async () => {
+  log.level(bunyan.FATAL + 1); // temporarily disable logging
+
+  const contentLinkPlugin = createContentLinkPlugin();
+  nock('https://test.api.ndla.no')
+    .get(`/taxonomy/v1/queries/resources?contentURI=urn:article:1`)
+    .reply(500, {});
+
+  const resource = await contentLinkPlugin.fetchResource({
+    data: { contentId: '1' },
+  });
+
+  expect(resource).toEqual({
+    data: { contentId: '1' },
+    path: `article/1`,
+  });
+  log.level(bunyan.INFO);
+});
+
+test('embedToHtml should return anchor tag with path', async () => {
+  const contentLinkPlugin = createContentLinkPlugin();
+
+  expect(
+    contentLinkPlugin.embedToHTML(
+      {
+        embed: {},
+        data: { linkText: 'text', contentId: '1' },
+        path: 'urn:test:1',
+      },
+      'nb'
+    )
+  ).toMatchSnapshot();
+});

--- a/src/plugins/contentLinkPlugin.js
+++ b/src/plugins/contentLinkPlugin.js
@@ -7,21 +7,45 @@
  */
 
 import { ndlaFrontendUrl } from '../config';
+import { fetchArticleResource } from '../api/taxonomyApi';
+import log from '../utils/logger';
 
 export default function createContentLinkPlugin() {
+  async function fetchResource(embed, accessToken, lang) {
+    try {
+      const resource = await fetchArticleResource(
+        embed.data.contentId,
+        accessToken,
+        lang
+      );
+
+      const urnPath = resource.path
+        .split('/')
+        .map(s => (s !== '' ? `urn:${s}` : s))
+        .join('/');
+      const fullPath = `article${urnPath}/${embed.data.contentId}`;
+
+      return { ...embed, path: fullPath };
+    } catch (error) {
+      log.error(error);
+      return { ...embed, path: `article/${embed.data.contentId}` };
+    }
+  }
+
   const embedToHTML = (embed, lang) => {
     if (embed.data.openIn === 'new-context') {
-      return `<a href="${ndlaFrontendUrl}/${lang}/article/${
-        embed.data.contentId
+      return `<a href="${ndlaFrontendUrl}/${lang}/${
+        embed.path
       }" target="_blank" rel="noopener noreferrer">${embed.data.linkText}</a>`;
     }
-    return `<a href="${ndlaFrontendUrl}/${lang}/article/${
-      embed.data.contentId
-    }">${embed.data.linkText}</a>`;
+    return `<a href="${ndlaFrontendUrl}/${lang}/${embed.path}">${
+      embed.data.linkText
+    }</a>`;
   };
 
   return {
     resource: 'content-link',
+    fetchResource,
     embedToHTML,
   };
 }


### PR DESCRIPTION
contentLinkPlugin now has a fetchResource function that fetches
taxonomyPath for the given article. Falls back to old path without
taxonomy if not found.