### PR TITLE
#879: Related content url now falls back to url without taxonomy

### DIFF
--- a/src/plugins/__tests__/__snapshots__/relatedContentPlugin-test.js.snap
+++ b/src/plugins/__tests__/__snapshots__/relatedContentPlugin-test.js.snap
@@ -97,7 +97,7 @@ Object {
       "introduction": Object {
         "introduction": "introduction2",
       },
-      "resource": Object {},
+      "resource": undefined,
       "title": Object {
         "title": "title2",
       },

--- a/src/plugins/__tests__/__snapshots__/relatedContentPlugin-test.js.snap
+++ b/src/plugins/__tests__/__snapshots__/relatedContentPlugin-test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`embedToHtml should return fallback url if no resource was found 1`] = `"<div><h2 class=\\"c-related-articles__component-title\\">Relaterte arikler</h2><div class=\\"c-related-articles\\"><div class=\\"c-related-articles__item c-related-articles__item--subject-material\\"><h3 class=\\"c-related-articles__title\\"><div class=\\"c-content-type-badge c-content-type-badge--subject-material c-content-type-badge--small c-content-type-badge--background\\"><svg fill=\\"currentColor\\" preserveAspectRatio=\\"xMidYMid meet\\" height=\\"1em\\" width=\\"1em\\" class=\\"c-icon\\" viewBox=\\"0 0 24 24\\" data-license=\\"Apache License 2.0\\" data-source=\\"Material Design\\" style=\\"vertical-align:middle\\"><g><title>Fagstoff</title><g id=\\"Page-1\\" stroke=\\"none\\" fill=\\"none\\" stroke-width=\\"1\\" fill-rule=\\"evenodd\\"><g id=\\"fagstoff\\"><g><polygon id=\\"Shape\\" points=\\"0 0 24 0 24 24 0 24\\"></polygon><path d=\\"M0,10 L0,8 L11,8 L11,10 L0,10 Z M24,0 L24,2 L0,2 L0,0 L24,0 Z M24,4 L24,6 L0,6 L0,4 L24,4 Z M13,8 L24,15.5 L13,23 L13,8 Z\\" id=\\"shape\\" fill=\\"currentColor\\"></path></g></g></g></g></svg></div><a href=\\"/article/1231\\" class=\\"c-related-articles__link\\">t1</a></h3><p class=\\"c-related-articles__description\\">m1</p></div><div class=\\"c-related-articles__item c-related-articles__item--subject-material\\"><h3 class=\\"c-related-articles__title\\"><div class=\\"c-content-type-badge c-content-type-badge--subject-material c-content-type-badge--small c-content-type-badge--background\\"><svg fill=\\"currentColor\\" preserveAspectRatio=\\"xMidYMid meet\\" height=\\"1em\\" width=\\"1em\\" class=\\"c-icon\\" viewBox=\\"0 0 24 24\\" data-license=\\"Apache License 2.0\\" data-source=\\"Material Design\\" style=\\"vertical-align:middle\\"><g><title>Fagstoff</title><g id=\\"Page-1\\" stroke=\\"none\\" fill=\\"none\\" stroke-width=\\"1\\" fill-rule=\\"evenodd\\"><g id=\\"fagstoff\\"><g><polygon id=\\"Shape\\" points=\\"0 0 24 0 24 24 0 24\\"></polygon><path d=\\"M0,10 L0,8 L11,8 L11,10 L0,10 Z M24,0 L24,2 L0,2 L0,0 L24,0 Z M24,4 L24,6 L0,6 L0,4 L24,4 Z M13,8 L24,15.5 L13,23 L13,8 Z\\" id=\\"shape\\" fill=\\"currentColor\\"></path></g></g></g></g></svg></div><a href=\\"/subjects/subject:4/topic:1:172816/topic:1:178048/resource:1:74420\\" class=\\"c-related-articles__link\\">t2</a></h3><p class=\\"c-related-articles__description\\">m2</p></div></div></div>"`;
+
 exports[`fetchResource for two related articles 1`] = `
 Object {
   "articles": Array [
@@ -44,7 +46,7 @@ Object {
 }
 `;
 
-exports[`fetchResource for two related articles, where one fails 1`] = `
+exports[`fetchResource for two related articles, where one could not be fetched from article-api 1`] = `
 Object {
   "articles": Array [
     Object {
@@ -62,6 +64,42 @@ Object {
       },
       "title": Object {
         "title": "title1",
+      },
+    },
+  ],
+  "data": Object {
+    "articleIds": "1,2",
+  },
+}
+`;
+
+exports[`fetchResource for two related articles, where one could not be fetched from taxonomy-api 1`] = `
+Object {
+  "articles": Array [
+    Object {
+      "introduction": Object {
+        "introduction": "introduction1",
+      },
+      "resource": Object {
+        "path": "/subject:12/topic:1:183846/topic:1:183935/resource:1:110269",
+        "resourceTypes": Array [
+          Object {
+            "id": "urn:resourcetype:tasksAndActivities",
+            "name": "Oppgaver og aktiviteter",
+          },
+        ],
+      },
+      "title": Object {
+        "title": "title1",
+      },
+    },
+    Object {
+      "introduction": Object {
+        "introduction": "introduction2",
+      },
+      "resource": Object {},
+      "title": Object {
+        "title": "title2",
       },
     },
   ],

--- a/src/plugins/relatedContentPlugin.js
+++ b/src/plugins/relatedContentPlugin.js
@@ -93,8 +93,7 @@ export default function createRelatedContentPlugin() {
           }),
         ]);
 
-        if (article === undefined) return undefined;
-        return { ...article, resource };
+        return article ? { ...article, resource } : undefined;
       })
     );
 

--- a/src/plugins/relatedContentPlugin.js
+++ b/src/plugins/relatedContentPlugin.js
@@ -52,11 +52,12 @@ const mapping = {
 };
 
 const getRelatedArticleProps = (resource, articleId) => {
-  const to = resource.path
-    ? `/subjects${resource.path}`
-    : `/article/${articleId}`;
+  const to =
+    resource && resource.path
+      ? `/subjects${resource.path}`
+      : `/article/${articleId}`;
 
-  if (!resource.resourceTypes) {
+  if (!resource || !resource.resourceTypes) {
     return { ...mapping.default, to };
   }
 
@@ -83,17 +84,17 @@ export default function createRelatedContentPlugin() {
       articleIds.map(async id => {
         const [article, resource] = await Promise.all([
           fetchArticle(id, accessToken, lang).catch(error => {
-            log.warn(error);
+            log.error(error);
             return undefined;
           }),
           fetchArticleResource(id, accessToken, lang).catch(error => {
-            log.warn(error);
+            log.error(error);
             return undefined;
           }),
         ]);
 
         if (article === undefined) return undefined;
-        return { ...article, resource: resource || {} };
+        return { ...article, resource };
       })
     );
 

--- a/src/plugins/relatedContentPlugin.js
+++ b/src/plugins/relatedContentPlugin.js
@@ -81,22 +81,18 @@ export default function createRelatedContentPlugin() {
 
     const articlesWithResource = await Promise.all(
       articleIds.map(async id => {
-        let article;
-        let resource;
+        const [article, resource] = await Promise.all([
+          fetchArticle(id, accessToken, lang).catch(error => {
+            log.warn(error);
+            return undefined;
+          }),
+          fetchArticleResource(id, accessToken, lang).catch(error => {
+            log.warn(error);
+            return undefined;
+          }),
+        ]);
 
-        try {
-          article = await fetchArticle(id, accessToken, lang);
-        } catch (error) {
-          log.error(error);
-          return undefined;
-        }
-
-        try {
-          resource = await fetchArticleResource(id, accessToken, lang);
-        } catch (error) {
-          log.error(`Failed to fetch taxonomy for ${id} with error: `, error);
-        }
-
+        if (article === undefined) return undefined;
         return { ...article, resource: resource || {} };
       })
     );


### PR DESCRIPTION
If article can be found in article-api, but not in taxonomy, the related
content are still rendered, but with a simple /article/\<id\> url rather
than the full context url.