### PR TITLE
Add decoding of code

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "cors": "^2.8.5",
     "defined": "1.0.0",
     "express": "^4.16.4",
+    "he": "^1.2.0",
     "http-status": "^1.3.1",
     "intl-format-cache": "^2.1.0",
     "intl-messageformat": "^2.2.0",

--- a/src/plugins/codePlugin.js
+++ b/src/plugins/codePlugin.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import he from 'he';
 import { Codeblock } from '@ndla/code';
 import { renderString } from '../utils/render';
 
@@ -15,7 +16,7 @@ export default function createCodePlugin(options = {}) {
     const { codeContent, codeFormat } = embed.data;
     return renderString(
       <figure className="c-figure">
-        <Codeblock code={codeContent} format={codeFormat} />
+        <Codeblock code={he.decode(codeContent)} format={codeFormat} />
       </figure>
     );
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3310,6 +3310,11 @@ hastscript@^5.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 highlight.js@^10.1.1:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.2.0.tgz#367151bcf813adebc54822f1cb51d2e1e599619f"


### PR DESCRIPTION
Fordi vi la til lagring av html-encoda kode må vi decode ved visning.

Test: Legg til htmlkode i artikkel i ed og klikk på forhåndsvis. Vil funke når eg har deploya article-converter til test fra branch.