### PR TITLE
Extra check before rendering metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ndla/i18n": "^0.5.1",
     "@ndla/licenses": "^0.6.39",
     "@ndla/notion": "^0.3.0",
-    "@ndla/ui": "^0.30.3",
+    "@ndla/ui": "^0.30.5",
     "@ndla/util": "^0.4.4",
     "body-parser": "^1.18.3",
     "bunyan": "^1.8.13",

--- a/src/plugins/audioPlugin.js
+++ b/src/plugins/audioPlugin.js
@@ -31,11 +31,13 @@ export default function createAudioPlugin() {
 
   const getMetaData = embed => {
     const { audio } = embed;
-    return {
-      title: audio.title.title,
-      copyright: audio.copyright,
-      src: audio.audioFile.url,
-    };
+    if (audio) {
+      return {
+        title: audio.title.title,
+        copyright: audio.copyright,
+        src: audio.audioFile.url,
+      };
+    }
   };
 
   const onError = ({ audio }, locale) => {

--- a/src/plugins/conceptPlugin.js
+++ b/src/plugins/conceptPlugin.js
@@ -59,11 +59,13 @@ export default function createConceptPlugin(options = {}) {
 
   const getMetaData = embed => {
     const { concept } = embed;
-    return {
-      title: concept.title.title,
-      copyright: concept.copyright,
-      src: getEmbedSrc(concept),
-    };
+    if (concept) {
+      return {
+        title: concept.title.title,
+        copyright: concept.copyright,
+        src: getEmbedSrc(concept),
+      };
+    }
   };
 
   const renderMarkdown = text => {

--- a/src/plugins/imagePlugin.js
+++ b/src/plugins/imagePlugin.js
@@ -163,12 +163,14 @@ export default function createImagePlugin(options = { concept: false }) {
 
   const getMetaData = embed => {
     const { image } = embed;
-    return {
-      title: image.title.title,
-      altText: image.alttext.alttext,
-      copyright: image.copyright,
-      src: image.imageUrl,
-    };
+    if (image) {
+      return {
+        title: image.title.title,
+        altText: image.alttext.alttext,
+        copyright: image.copyright,
+        src: image.imageUrl,
+      };
+    }
   };
 
   const onError = (embed, locale) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1081,10 +1081,10 @@
   dependencies:
     "@ndla/core" "^0.6.32"
 
-"@ndla/ui@^0.30.3":
-  version "0.30.3"
-  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-0.30.3.tgz#765ac532dd1c5cbbe9b0eb092fc344dc34805f3c"
-  integrity sha512-Es90R/bsa4LdFxGjxwYnP0CovGK3CUUxIU5Y6iGHXRz3SVDfOOYHjZEsfb9qGeioroOyxI6fuxnARq0ILFScng==
+"@ndla/ui@^0.30.5":
+  version "0.30.5"
+  resolved "https://registry.yarnpkg.com/@ndla/ui/-/ui-0.30.5.tgz#77528a5cdbe07ebf4b49a75d0eb29ac421c156d6"
+  integrity sha512-vbiHlmlijfyDdI7pQZDHhy7dRLT184Hk0ZubLpGX9ID7L8pj0u07PHhVsV/ReE9nrosqi1dvcpx6ciEDvf557Q==
   dependencies:
     "@ndla/button" "^0.3.43"
     "@ndla/carousel" "^0.3.32"


### PR DESCRIPTION
Fikser krasj oppstått i prod der en forklaring hadde et bilde som blei sletta som visuelt element.