### PR TITLE
2410 inline visning av pdf i artikkel

### DIFF
--- a/src/__tests__/integration-tests/article13349/__snapshots__/article13349-test.js.snap
+++ b/src/__tests__/integration-tests/article13349/__snapshots__/article13349-test.js.snap
@@ -51,49 +51,47 @@ exports[`app/fetchAndTransformArticle 13349 2`] = `
 "<section>
   <aside class=\\"c-aside c-aside--wideScreen\\">
     <div class=\\"c-aside__content\\">
-      <div>
-        <section class=\\"c-file-list\\">
-          <h1 class=\\"c-file-list__heading\\">Filer</h1>
-          <ul class=\\"c-file-list__files\\">
-            <li class=\\"c-file-list__item\\">
-              <a
-                href=\\"https://staging.api.ndla.no/files/82255/Gant diagram.pdf\\"
-                class=\\"c-file-list__link\\"
-                target=\\"_blank\\"
-                aria-label=\\"Gantt-diagram (PDF)\\"
-                aria-describedby=\\"testid_pdf\\"
-                ><svg
-                  fill=\\"currentColor\\"
-                  preserveAspectRatio=\\"xMidYMid meet\\"
-                  height=\\"1em\\"
-                  width=\\"1em\\"
-                  class=\\"c-icon\\"
-                  viewBox=\\"0 0 24 24\\"
-                  data-license=\\"Apache License 2.0\\"
-                  data-source=\\"Material Design\\"
-                  style=\\"vertical-align:middle\\"
-                >
-                  <title>Download</title>
-                  <g>
-                    <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-                    <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-                  </g></svg
-                ><span class=\\"c-file-list__link-text\\"
-                  ><span>Gantt-diagram (PDF)</span></span
-                ><span
-                  class=\\"c-file-list__tooltip\\"
-                  aria-hidden=\\"true\\"
-                  role=\\"tooltip\\"
-                  id=\\"testid_pdf\\"
-                  ><span class=\\"c-file-list__tooltip-text\\"
-                    >Last ned fil: Gant diagram.pdf</span
-                  ></span
-                ></a
+      <section class=\\"c-file-list\\">
+        <h1 class=\\"c-file-list__heading\\">Filer</h1>
+        <ul class=\\"c-file-list__files\\">
+          <li class=\\"c-file-list__item\\">
+            <a
+              href=\\"https://staging.api.ndla.no/files/82255/Gant diagram.pdf\\"
+              class=\\"c-file-list__link\\"
+              target=\\"_blank\\"
+              aria-label=\\"Gantt-diagram (PDF)\\"
+              aria-describedby=\\"testid_pdf\\"
+              ><svg
+                fill=\\"currentColor\\"
+                preserveAspectRatio=\\"xMidYMid meet\\"
+                height=\\"1em\\"
+                width=\\"1em\\"
+                class=\\"c-icon\\"
+                viewBox=\\"0 0 24 24\\"
+                data-license=\\"Apache License 2.0\\"
+                data-source=\\"Material Design\\"
+                style=\\"vertical-align:middle\\"
               >
-            </li>
-          </ul>
-        </section>
-      </div>
+                <title>Download</title>
+                <g>
+                  <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+                  <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+                </g></svg
+              ><span class=\\"c-file-list__link-text\\"
+                ><span>Gantt-diagram (PDF)</span></span
+              ><span
+                class=\\"c-file-list__tooltip\\"
+                aria-hidden=\\"true\\"
+                role=\\"tooltip\\"
+                id=\\"testid_pdf\\"
+                ><span class=\\"c-file-list__tooltip-text\\"
+                  >Last ned fil: Gant diagram.pdf</span
+                ></span
+              ></a
+            >
+          </li>
+        </ul>
+      </section>
       <p><strong>Lenke:</strong></p>
       <p>
         <a
@@ -157,49 +155,47 @@ exports[`app/fetchAndTransformArticle 13349 2`] = `
   </p>
   <aside class=\\"c-aside c-aside--narrowScreen\\">
     <div class=\\"c-aside__content\\">
-      <div>
-        <section class=\\"c-file-list\\">
-          <h1 class=\\"c-file-list__heading\\">Filer</h1>
-          <ul class=\\"c-file-list__files\\">
-            <li class=\\"c-file-list__item\\">
-              <a
-                href=\\"https://staging.api.ndla.no/files/82255/Gant diagram.pdf\\"
-                class=\\"c-file-list__link\\"
-                target=\\"_blank\\"
-                aria-label=\\"Gantt-diagram (PDF)\\"
-                aria-describedby=\\"testid_pdf\\"
-                ><svg
-                  fill=\\"currentColor\\"
-                  preserveAspectRatio=\\"xMidYMid meet\\"
-                  height=\\"1em\\"
-                  width=\\"1em\\"
-                  class=\\"c-icon\\"
-                  viewBox=\\"0 0 24 24\\"
-                  data-license=\\"Apache License 2.0\\"
-                  data-source=\\"Material Design\\"
-                  style=\\"vertical-align:middle\\"
-                >
-                  <title>Download</title>
-                  <g>
-                    <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-                    <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-                  </g></svg
-                ><span class=\\"c-file-list__link-text\\"
-                  ><span>Gantt-diagram (PDF)</span></span
-                ><span
-                  class=\\"c-file-list__tooltip\\"
-                  aria-hidden=\\"true\\"
-                  role=\\"tooltip\\"
-                  id=\\"testid_pdf\\"
-                  ><span class=\\"c-file-list__tooltip-text\\"
-                    >Last ned fil: Gant diagram.pdf</span
-                  ></span
-                ></a
+      <section class=\\"c-file-list\\">
+        <h1 class=\\"c-file-list__heading\\">Filer</h1>
+        <ul class=\\"c-file-list__files\\">
+          <li class=\\"c-file-list__item\\">
+            <a
+              href=\\"https://staging.api.ndla.no/files/82255/Gant diagram.pdf\\"
+              class=\\"c-file-list__link\\"
+              target=\\"_blank\\"
+              aria-label=\\"Gantt-diagram (PDF)\\"
+              aria-describedby=\\"testid_pdf\\"
+              ><svg
+                fill=\\"currentColor\\"
+                preserveAspectRatio=\\"xMidYMid meet\\"
+                height=\\"1em\\"
+                width=\\"1em\\"
+                class=\\"c-icon\\"
+                viewBox=\\"0 0 24 24\\"
+                data-license=\\"Apache License 2.0\\"
+                data-source=\\"Material Design\\"
+                style=\\"vertical-align:middle\\"
               >
-            </li>
-          </ul>
-        </section>
-      </div>
+                <title>Download</title>
+                <g>
+                  <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+                  <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+                </g></svg
+              ><span class=\\"c-file-list__link-text\\"
+                ><span>Gantt-diagram (PDF)</span></span
+              ><span
+                class=\\"c-file-list__tooltip\\"
+                aria-hidden=\\"true\\"
+                role=\\"tooltip\\"
+                id=\\"testid_pdf\\"
+                ><span class=\\"c-file-list__tooltip-text\\"
+                  >Last ned fil: Gant diagram.pdf</span
+                ></span
+              ></a
+            >
+          </li>
+        </ul>
+      </section>
       <p><strong>Lenke:</strong></p>
       <p>
         <a

--- a/src/__tests__/integration-tests/article13349/__snapshots__/article13349-test.js.snap
+++ b/src/__tests__/integration-tests/article13349/__snapshots__/article13349-test.js.snap
@@ -51,47 +51,49 @@ exports[`app/fetchAndTransformArticle 13349 2`] = `
 "<section>
   <aside class=\\"c-aside c-aside--wideScreen\\">
     <div class=\\"c-aside__content\\">
-      <section class=\\"c-file-list\\">
-        <h1 class=\\"c-file-list__heading\\">Filer</h1>
-        <ul class=\\"c-file-list__files\\">
-          <li class=\\"c-file-list__item\\">
-            <a
-              href=\\"https://staging.api.ndla.no/files/82255/Gant diagram.pdf\\"
-              class=\\"c-file-list__link\\"
-              target=\\"_blank\\"
-              aria-label=\\"Gantt-diagram (PDF)\\"
-              aria-describedby=\\"testid_pdf\\"
-              ><svg
-                fill=\\"currentColor\\"
-                preserveAspectRatio=\\"xMidYMid meet\\"
-                height=\\"1em\\"
-                width=\\"1em\\"
-                class=\\"c-icon\\"
-                viewBox=\\"0 0 24 24\\"
-                data-license=\\"Apache License 2.0\\"
-                data-source=\\"Material Design\\"
-                style=\\"vertical-align:middle\\"
+      <div>
+        <section class=\\"c-file-list\\">
+          <h1 class=\\"c-file-list__heading\\">Filer</h1>
+          <ul class=\\"c-file-list__files\\">
+            <li class=\\"c-file-list__item\\">
+              <a
+                href=\\"https://staging.api.ndla.no/files/82255/Gant diagram.pdf\\"
+                class=\\"c-file-list__link\\"
+                target=\\"_blank\\"
+                aria-label=\\"Gantt-diagram (PDF)\\"
+                aria-describedby=\\"testid_pdf\\"
+                ><svg
+                  fill=\\"currentColor\\"
+                  preserveAspectRatio=\\"xMidYMid meet\\"
+                  height=\\"1em\\"
+                  width=\\"1em\\"
+                  class=\\"c-icon\\"
+                  viewBox=\\"0 0 24 24\\"
+                  data-license=\\"Apache License 2.0\\"
+                  data-source=\\"Material Design\\"
+                  style=\\"vertical-align:middle\\"
+                >
+                  <title>Download</title>
+                  <g>
+                    <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+                    <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+                  </g></svg
+                ><span class=\\"c-file-list__link-text\\"
+                  ><span>Gantt-diagram (PDF)</span></span
+                ><span
+                  class=\\"c-file-list__tooltip\\"
+                  aria-hidden=\\"true\\"
+                  role=\\"tooltip\\"
+                  id=\\"testid_pdf\\"
+                  ><span class=\\"c-file-list__tooltip-text\\"
+                    >Last ned fil: Gant diagram.pdf</span
+                  ></span
+                ></a
               >
-                <title>Download</title>
-                <g>
-                  <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-                  <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-                </g></svg
-              ><span class=\\"c-file-list__link-text\\"
-                ><span>Gantt-diagram (PDF)</span></span
-              ><span
-                class=\\"c-file-list__tooltip\\"
-                aria-hidden=\\"true\\"
-                role=\\"tooltip\\"
-                id=\\"testid_pdf\\"
-                ><span class=\\"c-file-list__tooltip-text\\"
-                  >Last ned fil: Gant diagram.pdf</span
-                ></span
-              ></a
-            >
-          </li>
-        </ul>
-      </section>
+            </li>
+          </ul>
+        </section>
+      </div>
       <p><strong>Lenke:</strong></p>
       <p>
         <a
@@ -155,47 +157,49 @@ exports[`app/fetchAndTransformArticle 13349 2`] = `
   </p>
   <aside class=\\"c-aside c-aside--narrowScreen\\">
     <div class=\\"c-aside__content\\">
-      <section class=\\"c-file-list\\">
-        <h1 class=\\"c-file-list__heading\\">Filer</h1>
-        <ul class=\\"c-file-list__files\\">
-          <li class=\\"c-file-list__item\\">
-            <a
-              href=\\"https://staging.api.ndla.no/files/82255/Gant diagram.pdf\\"
-              class=\\"c-file-list__link\\"
-              target=\\"_blank\\"
-              aria-label=\\"Gantt-diagram (PDF)\\"
-              aria-describedby=\\"testid_pdf\\"
-              ><svg
-                fill=\\"currentColor\\"
-                preserveAspectRatio=\\"xMidYMid meet\\"
-                height=\\"1em\\"
-                width=\\"1em\\"
-                class=\\"c-icon\\"
-                viewBox=\\"0 0 24 24\\"
-                data-license=\\"Apache License 2.0\\"
-                data-source=\\"Material Design\\"
-                style=\\"vertical-align:middle\\"
+      <div>
+        <section class=\\"c-file-list\\">
+          <h1 class=\\"c-file-list__heading\\">Filer</h1>
+          <ul class=\\"c-file-list__files\\">
+            <li class=\\"c-file-list__item\\">
+              <a
+                href=\\"https://staging.api.ndla.no/files/82255/Gant diagram.pdf\\"
+                class=\\"c-file-list__link\\"
+                target=\\"_blank\\"
+                aria-label=\\"Gantt-diagram (PDF)\\"
+                aria-describedby=\\"testid_pdf\\"
+                ><svg
+                  fill=\\"currentColor\\"
+                  preserveAspectRatio=\\"xMidYMid meet\\"
+                  height=\\"1em\\"
+                  width=\\"1em\\"
+                  class=\\"c-icon\\"
+                  viewBox=\\"0 0 24 24\\"
+                  data-license=\\"Apache License 2.0\\"
+                  data-source=\\"Material Design\\"
+                  style=\\"vertical-align:middle\\"
+                >
+                  <title>Download</title>
+                  <g>
+                    <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+                    <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+                  </g></svg
+                ><span class=\\"c-file-list__link-text\\"
+                  ><span>Gantt-diagram (PDF)</span></span
+                ><span
+                  class=\\"c-file-list__tooltip\\"
+                  aria-hidden=\\"true\\"
+                  role=\\"tooltip\\"
+                  id=\\"testid_pdf\\"
+                  ><span class=\\"c-file-list__tooltip-text\\"
+                    >Last ned fil: Gant diagram.pdf</span
+                  ></span
+                ></a
               >
-                <title>Download</title>
-                <g>
-                  <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-                  <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-                </g></svg
-              ><span class=\\"c-file-list__link-text\\"
-                ><span>Gantt-diagram (PDF)</span></span
-              ><span
-                class=\\"c-file-list__tooltip\\"
-                aria-hidden=\\"true\\"
-                role=\\"tooltip\\"
-                id=\\"testid_pdf\\"
-                ><span class=\\"c-file-list__tooltip-text\\"
-                  >Last ned fil: Gant diagram.pdf</span
-                ></span
-              ></a
-            >
-          </li>
-        </ul>
-      </section>
+            </li>
+          </ul>
+        </section>
+      </div>
       <p><strong>Lenke:</strong></p>
       <p>
         <a

--- a/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
+++ b/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
@@ -128,7 +128,7 @@ exports[`app/fetchAndTransformArticle 4835 2`] = `
     </ul>
   </section>
   <figure data-sizetype=\\"full\\" class=\\"c-figure u-float-full\\" id=\\"0-testid\\">
-    <h2>Forslag til &#xE5;rsplan 1P (PDF)</h2>
+    <h2>Forslag til &#xE5;rsplan 1P</h2>
     <iframe
       title=\\"Forslag til &#xE5;rsplan 1P\\"
       height=\\"600\\"

--- a/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
+++ b/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
@@ -50,121 +50,90 @@ Object {
 exports[`app/fetchAndTransformArticle 4835 2`] = `
 "<section>
   <p>Forslag til &#xE5;rsplan 1P</p>
-  <div>
-    <section class=\\"c-file-list\\">
-      <h1 class=\\"c-file-list__heading\\">Filer</h1>
-      <ul class=\\"c-file-list__files\\">
-        <li class=\\"c-file-list__item\\">
-          <a
-            href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.doc\\"
-            class=\\"c-file-list__link\\"
-            target=\\"_blank\\"
-            aria-label=\\"Forslag til &#xE5;rsplan 1P (DOC)\\"
-            aria-describedby=\\"testid_doc\\"
-            ><svg
-              fill=\\"currentColor\\"
-              preserveAspectRatio=\\"xMidYMid meet\\"
-              height=\\"1em\\"
-              width=\\"1em\\"
-              class=\\"c-icon\\"
-              viewBox=\\"0 0 24 24\\"
-              data-license=\\"Apache License 2.0\\"
-              data-source=\\"Material Design\\"
-              style=\\"vertical-align:middle\\"
-            >
-              <title>Download</title>
-              <g>
-                <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-                <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-              </g></svg
-            ><span class=\\"c-file-list__link-text\\"
-              ><span>Forslag til &#xE5;rsplan 1P (DOC)</span></span
-            ><span
-              class=\\"c-file-list__tooltip\\"
-              aria-hidden=\\"true\\"
-              role=\\"tooltip\\"
-              id=\\"testid_doc\\"
-              ><span class=\\"c-file-list__tooltip-text\\"
-                >Last ned fil: 1p_arsplan_2013-2014_nynorsk.doc</span
-              ></span
-            ></a
+  <section class=\\"c-file-list\\">
+    <h1 class=\\"c-file-list__heading\\">Filer</h1>
+    <ul class=\\"c-file-list__files\\">
+      <li class=\\"c-file-list__item\\">
+        <a
+          href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.doc\\"
+          class=\\"c-file-list__link\\"
+          target=\\"_blank\\"
+          aria-label=\\"Forslag til &#xE5;rsplan 1P (DOC)\\"
+          aria-describedby=\\"testid_doc\\"
+          ><svg
+            fill=\\"currentColor\\"
+            preserveAspectRatio=\\"xMidYMid meet\\"
+            height=\\"1em\\"
+            width=\\"1em\\"
+            class=\\"c-icon\\"
+            viewBox=\\"0 0 24 24\\"
+            data-license=\\"Apache License 2.0\\"
+            data-source=\\"Material Design\\"
+            style=\\"vertical-align:middle\\"
           >
-        </li>
-        <li class=\\"c-file-list__item\\">
-          <a
-            href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.odt\\"
-            class=\\"c-file-list__link\\"
-            target=\\"_blank\\"
-            aria-label=\\"Forslag til &#xE5;rsplan 1P (ODT)\\"
-            aria-describedby=\\"testid_odt\\"
-            ><svg
-              fill=\\"currentColor\\"
-              preserveAspectRatio=\\"xMidYMid meet\\"
-              height=\\"1em\\"
-              width=\\"1em\\"
-              class=\\"c-icon\\"
-              viewBox=\\"0 0 24 24\\"
-              data-license=\\"Apache License 2.0\\"
-              data-source=\\"Material Design\\"
-              style=\\"vertical-align:middle\\"
-            >
-              <title>Download</title>
-              <g>
-                <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-                <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-              </g></svg
-            ><span class=\\"c-file-list__link-text\\"
-              ><span>Forslag til &#xE5;rsplan 1P (ODT)</span></span
-            ><span
-              class=\\"c-file-list__tooltip\\"
-              aria-hidden=\\"true\\"
-              role=\\"tooltip\\"
-              id=\\"testid_odt\\"
-              ><span class=\\"c-file-list__tooltip-text\\"
-                >Last ned fil: 1p_arsplan_2013-2014_nynorsk.odt</span
-              ></span
-            ></a
+            <title>Download</title>
+            <g>
+              <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+              <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+            </g></svg
+          ><span class=\\"c-file-list__link-text\\"
+            ><span>Forslag til &#xE5;rsplan 1P (DOC)</span></span
+          ><span
+            class=\\"c-file-list__tooltip\\"
+            aria-hidden=\\"true\\"
+            role=\\"tooltip\\"
+            id=\\"testid_doc\\"
+            ><span class=\\"c-file-list__tooltip-text\\"
+              >Last ned fil: 1p_arsplan_2013-2014_nynorsk.doc</span
+            ></span
+          ></a
+        >
+      </li>
+      <li class=\\"c-file-list__item\\">
+        <a
+          href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.odt\\"
+          class=\\"c-file-list__link\\"
+          target=\\"_blank\\"
+          aria-label=\\"Forslag til &#xE5;rsplan 1P (ODT)\\"
+          aria-describedby=\\"testid_odt\\"
+          ><svg
+            fill=\\"currentColor\\"
+            preserveAspectRatio=\\"xMidYMid meet\\"
+            height=\\"1em\\"
+            width=\\"1em\\"
+            class=\\"c-icon\\"
+            viewBox=\\"0 0 24 24\\"
+            data-license=\\"Apache License 2.0\\"
+            data-source=\\"Material Design\\"
+            style=\\"vertical-align:middle\\"
           >
-        </li>
-        <li class=\\"c-file-list__item\\">
-          <a
-            href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.pdf\\"
-            class=\\"c-file-list__link\\"
-            target=\\"_blank\\"
-            aria-label=\\"Forslag til &#xE5;rsplan 1P (PDF)\\"
-            aria-describedby=\\"testid_pdf\\"
-            ><svg
-              fill=\\"currentColor\\"
-              preserveAspectRatio=\\"xMidYMid meet\\"
-              height=\\"1em\\"
-              width=\\"1em\\"
-              class=\\"c-icon\\"
-              viewBox=\\"0 0 24 24\\"
-              data-license=\\"Apache License 2.0\\"
-              data-source=\\"Material Design\\"
-              style=\\"vertical-align:middle\\"
-            >
-              <title>Download</title>
-              <g>
-                <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-                <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-              </g></svg
-            ><span class=\\"c-file-list__link-text\\"
-              ><span>Forslag til &#xE5;rsplan 1P (PDF)</span></span
-            ><span
-              class=\\"c-file-list__tooltip\\"
-              aria-hidden=\\"true\\"
-              role=\\"tooltip\\"
-              id=\\"testid_pdf\\"
-              ><span class=\\"c-file-list__tooltip-text\\"
-                >Last ned fil: 1p_arsplan_2013-2014_nynorsk.pdf</span
-              ></span
-            ></a
-          >
-        </li>
-      </ul>
-    </section>
-  </div>
+            <title>Download</title>
+            <g>
+              <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+              <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+            </g></svg
+          ><span class=\\"c-file-list__link-text\\"
+            ><span>Forslag til &#xE5;rsplan 1P (ODT)</span></span
+          ><span
+            class=\\"c-file-list__tooltip\\"
+            aria-hidden=\\"true\\"
+            role=\\"tooltip\\"
+            id=\\"testid_odt\\"
+            ><span class=\\"c-file-list__tooltip-text\\"
+              >Last ned fil: 1p_arsplan_2013-2014_nynorsk.odt</span
+            ></span
+          ></a
+        >
+      </li>
+    </ul>
+  </section>
+  <figure data-sizetype=\\"full\\" class=\\"c-figure u-float-full\\" id=\\"0-testid\\">
+    <iframe
+      title=\\"Forslag til &#xE5;rsplan 1P\\"
+      height=\\"600\\"
+      src=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.pdf\\"
+    ></iframe>
+  </figure>
 </section>
 "
 `;

--- a/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
+++ b/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
@@ -128,6 +128,7 @@ exports[`app/fetchAndTransformArticle 4835 2`] = `
     </ul>
   </section>
   <figure data-sizetype=\\"full\\" class=\\"c-figure u-float-full\\" id=\\"0-testid\\">
+    <h2>Forslag til &#xE5;rsplan 1P (PDF)</h2>
     <iframe
       title=\\"Forslag til &#xE5;rsplan 1P\\"
       height=\\"600\\"

--- a/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
+++ b/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
@@ -50,119 +50,121 @@ Object {
 exports[`app/fetchAndTransformArticle 4835 2`] = `
 "<section>
   <p>Forslag til &#xE5;rsplan 1P</p>
-  <section class=\\"c-file-list\\">
-    <h1 class=\\"c-file-list__heading\\">Filer</h1>
-    <ul class=\\"c-file-list__files\\">
-      <li class=\\"c-file-list__item\\">
-        <a
-          href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.doc\\"
-          class=\\"c-file-list__link\\"
-          target=\\"_blank\\"
-          aria-label=\\"Forslag til &#xE5;rsplan 1P (DOC)\\"
-          aria-describedby=\\"testid_doc\\"
-          ><svg
-            fill=\\"currentColor\\"
-            preserveAspectRatio=\\"xMidYMid meet\\"
-            height=\\"1em\\"
-            width=\\"1em\\"
-            class=\\"c-icon\\"
-            viewBox=\\"0 0 24 24\\"
-            data-license=\\"Apache License 2.0\\"
-            data-source=\\"Material Design\\"
-            style=\\"vertical-align:middle\\"
+  <div>
+    <section class=\\"c-file-list\\">
+      <h1 class=\\"c-file-list__heading\\">Filer</h1>
+      <ul class=\\"c-file-list__files\\">
+        <li class=\\"c-file-list__item\\">
+          <a
+            href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.doc\\"
+            class=\\"c-file-list__link\\"
+            target=\\"_blank\\"
+            aria-label=\\"Forslag til &#xE5;rsplan 1P (DOC)\\"
+            aria-describedby=\\"testid_doc\\"
+            ><svg
+              fill=\\"currentColor\\"
+              preserveAspectRatio=\\"xMidYMid meet\\"
+              height=\\"1em\\"
+              width=\\"1em\\"
+              class=\\"c-icon\\"
+              viewBox=\\"0 0 24 24\\"
+              data-license=\\"Apache License 2.0\\"
+              data-source=\\"Material Design\\"
+              style=\\"vertical-align:middle\\"
+            >
+              <title>Download</title>
+              <g>
+                <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+                <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+              </g></svg
+            ><span class=\\"c-file-list__link-text\\"
+              ><span>Forslag til &#xE5;rsplan 1P (DOC)</span></span
+            ><span
+              class=\\"c-file-list__tooltip\\"
+              aria-hidden=\\"true\\"
+              role=\\"tooltip\\"
+              id=\\"testid_doc\\"
+              ><span class=\\"c-file-list__tooltip-text\\"
+                >Last ned fil: 1p_arsplan_2013-2014_nynorsk.doc</span
+              ></span
+            ></a
           >
-            <title>Download</title>
-            <g>
-              <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-              <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-            </g></svg
-          ><span class=\\"c-file-list__link-text\\"
-            ><span>Forslag til &#xE5;rsplan 1P (DOC)</span></span
-          ><span
-            class=\\"c-file-list__tooltip\\"
-            aria-hidden=\\"true\\"
-            role=\\"tooltip\\"
-            id=\\"testid_doc\\"
-            ><span class=\\"c-file-list__tooltip-text\\"
-              >Last ned fil: 1p_arsplan_2013-2014_nynorsk.doc</span
-            ></span
-          ></a
-        >
-      </li>
-      <li class=\\"c-file-list__item\\">
-        <a
-          href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.odt\\"
-          class=\\"c-file-list__link\\"
-          target=\\"_blank\\"
-          aria-label=\\"Forslag til &#xE5;rsplan 1P (ODT)\\"
-          aria-describedby=\\"testid_odt\\"
-          ><svg
-            fill=\\"currentColor\\"
-            preserveAspectRatio=\\"xMidYMid meet\\"
-            height=\\"1em\\"
-            width=\\"1em\\"
-            class=\\"c-icon\\"
-            viewBox=\\"0 0 24 24\\"
-            data-license=\\"Apache License 2.0\\"
-            data-source=\\"Material Design\\"
-            style=\\"vertical-align:middle\\"
+        </li>
+        <li class=\\"c-file-list__item\\">
+          <a
+            href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.odt\\"
+            class=\\"c-file-list__link\\"
+            target=\\"_blank\\"
+            aria-label=\\"Forslag til &#xE5;rsplan 1P (ODT)\\"
+            aria-describedby=\\"testid_odt\\"
+            ><svg
+              fill=\\"currentColor\\"
+              preserveAspectRatio=\\"xMidYMid meet\\"
+              height=\\"1em\\"
+              width=\\"1em\\"
+              class=\\"c-icon\\"
+              viewBox=\\"0 0 24 24\\"
+              data-license=\\"Apache License 2.0\\"
+              data-source=\\"Material Design\\"
+              style=\\"vertical-align:middle\\"
+            >
+              <title>Download</title>
+              <g>
+                <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+                <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+              </g></svg
+            ><span class=\\"c-file-list__link-text\\"
+              ><span>Forslag til &#xE5;rsplan 1P (ODT)</span></span
+            ><span
+              class=\\"c-file-list__tooltip\\"
+              aria-hidden=\\"true\\"
+              role=\\"tooltip\\"
+              id=\\"testid_odt\\"
+              ><span class=\\"c-file-list__tooltip-text\\"
+                >Last ned fil: 1p_arsplan_2013-2014_nynorsk.odt</span
+              ></span
+            ></a
           >
-            <title>Download</title>
-            <g>
-              <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-              <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-            </g></svg
-          ><span class=\\"c-file-list__link-text\\"
-            ><span>Forslag til &#xE5;rsplan 1P (ODT)</span></span
-          ><span
-            class=\\"c-file-list__tooltip\\"
-            aria-hidden=\\"true\\"
-            role=\\"tooltip\\"
-            id=\\"testid_odt\\"
-            ><span class=\\"c-file-list__tooltip-text\\"
-              >Last ned fil: 1p_arsplan_2013-2014_nynorsk.odt</span
-            ></span
-          ></a
-        >
-      </li>
-      <li class=\\"c-file-list__item\\">
-        <a
-          href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.pdf\\"
-          class=\\"c-file-list__link\\"
-          target=\\"_blank\\"
-          aria-label=\\"Forslag til &#xE5;rsplan 1P (PDF)\\"
-          aria-describedby=\\"testid_pdf\\"
-          ><svg
-            fill=\\"currentColor\\"
-            preserveAspectRatio=\\"xMidYMid meet\\"
-            height=\\"1em\\"
-            width=\\"1em\\"
-            class=\\"c-icon\\"
-            viewBox=\\"0 0 24 24\\"
-            data-license=\\"Apache License 2.0\\"
-            data-source=\\"Material Design\\"
-            style=\\"vertical-align:middle\\"
+        </li>
+        <li class=\\"c-file-list__item\\">
+          <a
+            href=\\"https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.pdf\\"
+            class=\\"c-file-list__link\\"
+            target=\\"_blank\\"
+            aria-label=\\"Forslag til &#xE5;rsplan 1P (PDF)\\"
+            aria-describedby=\\"testid_pdf\\"
+            ><svg
+              fill=\\"currentColor\\"
+              preserveAspectRatio=\\"xMidYMid meet\\"
+              height=\\"1em\\"
+              width=\\"1em\\"
+              class=\\"c-icon\\"
+              viewBox=\\"0 0 24 24\\"
+              data-license=\\"Apache License 2.0\\"
+              data-source=\\"Material Design\\"
+              style=\\"vertical-align:middle\\"
+            >
+              <title>Download</title>
+              <g>
+                <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
+                <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+              </g></svg
+            ><span class=\\"c-file-list__link-text\\"
+              ><span>Forslag til &#xE5;rsplan 1P (PDF)</span></span
+            ><span
+              class=\\"c-file-list__tooltip\\"
+              aria-hidden=\\"true\\"
+              role=\\"tooltip\\"
+              id=\\"testid_pdf\\"
+              ><span class=\\"c-file-list__tooltip-text\\"
+                >Last ned fil: 1p_arsplan_2013-2014_nynorsk.pdf</span
+              ></span
+            ></a
           >
-            <title>Download</title>
-            <g>
-              <path d=\\"M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z\\" />
-              <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
-            </g></svg
-          ><span class=\\"c-file-list__link-text\\"
-            ><span>Forslag til &#xE5;rsplan 1P (PDF)</span></span
-          ><span
-            class=\\"c-file-list__tooltip\\"
-            aria-hidden=\\"true\\"
-            role=\\"tooltip\\"
-            id=\\"testid_pdf\\"
-            ><span class=\\"c-file-list__tooltip-text\\"
-              >Last ned fil: 1p_arsplan_2013-2014_nynorsk.pdf</span
-            ></span
-          ></a
-        >
-      </li>
-    </ul>
-  </section>
+        </li>
+      </ul>
+    </section>
+  </div>
 </section>
 "
 `;

--- a/src/__tests__/integration-tests/article4835/article4835.js
+++ b/src/__tests__/integration-tests/article4835/article4835.js
@@ -8,7 +8,7 @@ export default {
   },
   content: {
     content:
-      '<section><p>Forslag til årsplan 1P </p><div data-type="file"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="doc" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.doc"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="odt" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.odt"><embed data-render-inline="true" data-resource="file" data-title="Forslag til årsplan 1P" data-type="pdf" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.pdf"></div></section>',
+      '<section><p>Forslag til årsplan 1P </p><div data-type="file"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="doc" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.doc"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="odt" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.odt"><embed data-display="block" data-resource="file" data-title="Forslag til årsplan 1P" data-type="pdf" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.pdf"></div></section>',
     language: 'nn',
   },
   copyright: {

--- a/src/__tests__/integration-tests/article4835/article4835.js
+++ b/src/__tests__/integration-tests/article4835/article4835.js
@@ -8,7 +8,7 @@ export default {
   },
   content: {
     content:
-      '<section><p>Forslag til årsplan 1P </p><div data-type="file"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="doc" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.doc"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="odt" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.odt"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="pdf" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.pdf"></div></section>',
+      '<section><p>Forslag til årsplan 1P </p><div data-type="file"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="doc" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.doc"><embed data-resource="file" data-title="Forslag til årsplan 1P" data-type="odt" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.odt"><embed data-render-inline="true" data-resource="file" data-title="Forslag til årsplan 1P" data-type="pdf" data-url="https://test.api.ndla.no/files/103066/1p_arsplan_2013-2014_nynorsk.pdf"></div></section>',
     language: 'nn',
   },
   copyright: {

--- a/src/htmlTransformers.js
+++ b/src/htmlTransformers.js
@@ -98,12 +98,12 @@ const makeTheListFromDiv = async (content, div, locale) => {
   const filesPromises = content(div)
     .children()
     .map(async (_, file) => {
-      const { url, type, title } = file.data;
+      const { url, type, title, renderInline } = file.data;
       const fileExists = await checkIfFileExists(url);
       return {
         title,
         fileExists,
-        renderInline: file.data['render-inline'] === 'true',
+        renderInline,
         formats: [
           {
             url,

--- a/src/htmlTransformers.js
+++ b/src/htmlTransformers.js
@@ -7,10 +7,11 @@
  */
 
 import cheerio from 'cheerio';
+import { partition } from 'lodash';
 import {
   createAside,
   createFactbox,
-  createFileList,
+  createFileSection,
   createTable,
 } from './utils/htmlTagHelpers';
 import { createRelatedArticleList } from './utils/embedGroupHelpers';
@@ -97,11 +98,12 @@ const makeTheListFromDiv = async (content, div, locale) => {
   const filesPromises = content(div)
     .children()
     .map(async (_, file) => {
-      const { url, type, title } = file.data;
+      const { url, type, title, renderInline } = file.data;
       const fileExists = await checkIfFileExists(url);
       return {
         title,
         fileExists,
+        renderInline,
         formats: [
           {
             url,
@@ -115,10 +117,12 @@ const makeTheListFromDiv = async (content, div, locale) => {
 
   const files = await Promise.all(filesPromises);
 
-  return createFileList({
-    files: files.filter(f => f),
-    heading: t(locale, 'files'),
-  });
+  const [pdfs, fileList] = partition(
+    files,
+    f => f.formats[0].fileType === 'pdf' && f.renderInline
+  );
+
+  return createFileSection(fileList.filter(f => f), pdfs, t(locale, 'files'));
 };
 
 export const transformTables = (content, lang) =>

--- a/src/htmlTransformers.js
+++ b/src/htmlTransformers.js
@@ -98,12 +98,12 @@ const makeTheListFromDiv = async (content, div, locale) => {
   const filesPromises = content(div)
     .children()
     .map(async (_, file) => {
-      const { url, type, title, renderInline } = file.data;
+      const { url, type, title } = file.data;
       const fileExists = await checkIfFileExists(url);
       return {
         title,
         fileExists,
-        renderInline,
+        renderInline: file.data['render-inline'] === 'true',
         formats: [
           {
             url,

--- a/src/htmlTransformers.js
+++ b/src/htmlTransformers.js
@@ -98,12 +98,12 @@ const makeTheListFromDiv = async (content, div, locale) => {
   const filesPromises = content(div)
     .children()
     .map(async (_, file) => {
-      const { url, type, title, renderInline } = file.data;
+      const { url, type, title, display } = file.data;
       const fileExists = await checkIfFileExists(url);
       return {
         title,
         fileExists,
-        renderInline,
+        display,
         formats: [
           {
             url,
@@ -119,7 +119,7 @@ const makeTheListFromDiv = async (content, div, locale) => {
 
   const [pdfs, fileList] = partition(
     files,
-    f => f.formats[0].fileType === 'pdf' && f.renderInline
+    f => f.formats[0].fileType === 'pdf' && f.display === 'block'
   );
 
   return createFileSection(fileList.filter(f => f), pdfs, t(locale, 'files'));

--- a/src/utils/htmlTagHelpers.js
+++ b/src/utils/htmlTagHelpers.js
@@ -47,7 +47,7 @@ export function createFileSection(files, pdfs, heading) {
       )}
       {pdfs.map((pdf, index) => (
         <Figure key={`${index}-${figureId}`} id={`${index}-${figureId}`}>
-          <h2>{`${pdf.title} (PDF)`}</h2>
+          <h2>{pdf.title}</h2>
           <iframe title={pdf.title} height="600" src={pdf.formats[0].url} />
         </Figure>
       ))}

--- a/src/utils/htmlTagHelpers.js
+++ b/src/utils/htmlTagHelpers.js
@@ -11,6 +11,7 @@ import Aside from '@ndla/ui/lib/Aside';
 import Table from '@ndla/ui/lib/Table';
 import FactBox from '@ndla/ui/lib/FactBox';
 import FileList from '@ndla/ui/lib/FileList';
+import { Figure } from '@ndla/ui/lib/Figure';
 import t from '../locale/i18n';
 import { render } from './render';
 
@@ -36,9 +37,18 @@ export function createFactbox(props, children) {
   );
 }
 
-export function createFileList(props) {
+export function createFileSection(files, pdfs, heading) {
   const id = process.env.NODE_ENV === 'unittest' ? 'testid' : uuid();
-  return render(<FileList {...props} id={id} />);
+  return render(
+    <div>
+      {files.length && <FileList files={files} heading={heading} id={id} />}
+      {pdfs.map(pdf => (
+        <Figure>
+          <iframe title={pdf.title} height="600" src={pdf.formats[0].url} />
+        </Figure>
+      ))}
+    </div>
+  );
 }
 
 export function createTable(props, children, lang) {

--- a/src/utils/htmlTagHelpers.js
+++ b/src/utils/htmlTagHelpers.js
@@ -38,13 +38,16 @@ export function createFactbox(props, children) {
 }
 
 export function createFileSection(files, pdfs, heading) {
-  const id = process.env.NODE_ENV === 'unittest' ? 'testid' : uuid();
-  const id2 = process.env.NODE_ENV === 'unittest' ? 'testid' : uuid();
+  const filelistId = process.env.NODE_ENV === 'unittest' ? 'testid' : uuid();
+  const figureId = process.env.NODE_ENV === 'unittest' ? 'testid' : uuid();
   return render(
     <>
-      {files.length && <FileList files={files} heading={heading} id={id} />}
+      {files.length && (
+        <FileList files={files} heading={heading} id={filelistId} />
+      )}
       {pdfs.map((pdf, index) => (
-        <Figure key={`${index}-${id2}`} id={`${index}-${id2}`}>
+        <Figure key={`${index}-${figureId}`} id={`${index}-${figureId}`}>
+          <h2>{`${pdf.title} (PDF)`}</h2>
           <iframe title={pdf.title} height="600" src={pdf.formats[0].url} />
         </Figure>
       ))}

--- a/src/utils/htmlTagHelpers.js
+++ b/src/utils/htmlTagHelpers.js
@@ -44,7 +44,7 @@ export function createFileSection(files, pdfs, heading) {
     <>
       {files.length && <FileList files={files} heading={heading} id={id} />}
       {pdfs.map((pdf, index) => (
-        <Figure id={`${index}-${id2}`}>
+        <Figure key={`${index}-${id2}`} id={`${index}-${id2}`}>
           <iframe title={pdf.title} height="600" src={pdf.formats[0].url} />
         </Figure>
       ))}

--- a/src/utils/htmlTagHelpers.js
+++ b/src/utils/htmlTagHelpers.js
@@ -39,15 +39,16 @@ export function createFactbox(props, children) {
 
 export function createFileSection(files, pdfs, heading) {
   const id = process.env.NODE_ENV === 'unittest' ? 'testid' : uuid();
+  const id2 = process.env.NODE_ENV === 'unittest' ? 'testid' : uuid();
   return render(
-    <div>
+    <>
       {files.length && <FileList files={files} heading={heading} id={id} />}
-      {pdfs.map(pdf => (
-        <Figure>
+      {pdfs.map((pdf, index) => (
+        <Figure id={`${index}-${id2}`}>
           <iframe title={pdf.title} height="600" src={pdf.formats[0].url} />
         </Figure>
       ))}
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2410

Hører sammen med https://github.com/NDLANO/editorial-frontend/pull/883

Fil-embeds er oppdatert med en attributt "data-display". Dersom denne er satt til "block" og filtypen er "pdf" så skal PDFen vises i en iframe.

How to test:
1. yarn start
2. Editorial yarn start-with-local-converter (branch 2410-inline-visning-av-pdf-i-artikkel)
3. Åpne en artikkel, feks http://localhost:3000/preview/22741/nb 
4. Marker ingen, en eller flere PDF-filer og sjekk at de markerte pdf'ene vises i forhåndsvisning av artikkel.