### PR TITLE
Adding podcast-fields to audioPlugin

### DIFF
--- a/src/__tests__/__snapshots__/replacer-test.js.snap
+++ b/src/__tests__/__snapshots__/replacer-test.js.snap
@@ -2,11 +2,7 @@
 
 exports[`replacer/replaceEmbedsInHtml replace audio embeds 1`] = `
 "<section>
-  <figure
-    data-sizetype=\\"full-column\\"
-    class=\\"c-figure c-figure--full-column\\"
-    id=\\"figure-1\\"
-  >
+  <figure data-sizetype=\\"full\\" class=\\"c-figure u-float-full\\" id=\\"figure-1\\">
     <style data-emotion-css=\\"jkv5q-Heading\\">
       .css-jkv5q-Heading {
         font-size: 20px;

--- a/src/__tests__/__snapshots__/replacer-test.js.snap
+++ b/src/__tests__/__snapshots__/replacer-test.js.snap
@@ -184,7 +184,7 @@ exports[`replacer/replaceEmbedsInHtml replace audio embeds 1`] = `
             }</style
           ><button
             type=\\"button\\"
-            data-audio-text-button-id=\\"static-render-1\\"
+            data-audio-text-button-id=\\"static-render-1-nb\\"
             class=\\"e1wmpntw10 css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton e1ljv5qk0\\"
           >
             Tekstversjon
@@ -913,7 +913,7 @@ exports[`replacer/replaceEmbedsInHtml replace audio embeds 1`] = `
       }
     </style>
     <div
-      id=\\"static-render-1\\"
+      id=\\"static-render-1-nb\\"
       hidden
       class=\\"css-dk8xs8-TextVersionWrapper e1wmpntw7\\"
     >
@@ -1063,7 +1063,7 @@ exports[`replacer/replaceEmbedsInHtml replace audio embeds 1`] = `
           }</style
         ><button
           type=\\"button\\"
-          data-audio-text-button-id=\\"static-render-1\\"
+          data-audio-text-button-id=\\"static-render-1-nb\\"
           class=\\"e1wmpntw10 css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton e1ljv5qk0\\"
         >
           <svg

--- a/src/__tests__/__snapshots__/replacer-test.js.snap
+++ b/src/__tests__/__snapshots__/replacer-test.js.snap
@@ -3,15 +3,195 @@
 exports[`replacer/replaceEmbedsInHtml replace audio embeds 1`] = `
 "<section>
   <figure data-sizetype=\\"full\\" class=\\"c-figure u-float-full\\" id=\\"figure-1\\">
-    <style data-emotion-css=\\"jkv5q-Heading\\">
-      .css-jkv5q-Heading {
-        font-size: 20px;
-        font-size: 1.1111111111111112rem;
-        line-height: 20px;
-        margin: 13px 0;
+    <style data-emotion-css=\\"11nwywh-InfoWrapper\\">
+      .css-11nwywh-InfoWrapper {
+        border: 1px solid #deebf6;
+        border-bottom: 0;
+        display: -webkit-box;
+        display: -webkit-flex;
+        display: -ms-flexbox;
+        display: flex;
+      }
+      @media (max-width: 48em) {
+        .css-11nwywh-InfoWrapper {
+          display: block;
+        }
       }
     </style>
-    <h2 class=\\"css-jkv5q-Heading e1wmpntw0\\">Tittel</h2>
+    <div class=\\"css-11nwywh-InfoWrapper e1wmpntw1\\">
+      <style data-emotion-css=\\"c1gs8i-TextWrapper\\">
+        .css-c1gs8i-TextWrapper {
+          padding: 26px 13px 13px;
+        }
+        @media (min-width: 37.5625em) {
+          .css-c1gs8i-TextWrapper {
+            padding: 26px;
+          }
+        }
+        @media (min-width: 48em) {
+          .css-c1gs8i-TextWrapper {
+            padding: 26px 32.5px;
+          }
+        }
+      </style>
+      <div class=\\"css-c1gs8i-TextWrapper e1wmpntw3\\">
+        <style data-emotion-css=\\"1uggs1w-Title\\">
+          .css-1uggs1w-Title {
+            font-size: 22px;
+            font-size: 1.2222222222222223rem;
+            line-height: 30px;
+            margin: 0 0 13px;
+          }
+        </style>
+        <h2 class=\\"css-1uggs1w-Title e1wmpntw4\\">Tittel</h2>
+        <style data-emotion-css=\\"eqqafz-Description\\">
+          .css-eqqafz-Description {
+            font-size: 16px;
+            font-size: 0.8888888888888888rem;
+            line-height: 30px;
+            font-family: \\"Source Sans Pro\\", Helvetica, Arial, STKaiti,
+              \\"华文楷体\\", KaiTi, SimKai, \\"楷体\\", KaiU, DFKai-SB, \\"標楷體\\",
+              SongTi, \\"宋体\\", sans-serif;
+            margin: 0;
+          }
+        </style>
+        <p class=\\"css-eqqafz-Description e1wmpntw5\\"><span></span></p>
+        <style data-emotion-css=\\"pq54rc-LinkToTextVersionWrapper\\">
+          .css-pq54rc-LinkToTextVersionWrapper {
+            margin-top: 26px;
+          }
+        </style>
+        <div class=\\"css-pq54rc-LinkToTextVersionWrapper e1wmpntw6\\">
+          <style data-emotion-css=\\"2bx46a-LinkButton\\">
+            .css-2bx46a-LinkButton {
+              box-shadow: none;
+              padding-left: 0;
+              padding-right: 4px;
+              min-height: 32.5px;
+              font-size: 16px;
+              font-size: 0.8888888888888888rem;
+              line-height: 25px;
+              -webkit-flex: 0 0 auto;
+              -ms-flex: 0 0 auto;
+              flex: 0 0 auto;
+            }
+            .css-2bx46a-LinkButton:hover,
+            .css-2bx46a-LinkButton:focus {
+              box-shadow: inset 0 -1px;
+            }</style
+          ><style
+            data-emotion-css=\\"f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton\\"
+          >
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton {
+              display: inline-block;
+              color: #ffffff;
+              background-color: #20588f;
+              border: 2px solid #20588f;
+              border-radius: 4px;
+              padding: 4px 13px;
+              outline-width: 0;
+              cursor: pointer;
+              -webkit-text-decoration: none;
+              text-decoration: none;
+              font-size: 16px;
+              font-size: 0.8888888888888888rem;
+              line-height: 1.625;
+              font-family: \\"Source Sans Pro\\", Helvetica, Arial, STKaiti,
+                \\"华文楷体\\", KaiTi, SimKai, \\"楷体\\", KaiU, DFKai-SB, \\"標楷體\\",
+                SongTi, \\"宋体\\", sans-serif;
+              font-weight: 700;
+              -webkit-transition: all 0.2s cubic-bezier(0.17, 0.04, 0.03, 0.94);
+              transition: all 0.2s cubic-bezier(0.17, 0.04, 0.03, 0.94);
+              box-shadow: none;
+              text-align: center;
+              -webkit-transition: background-color none;
+              transition: background-color none;
+              padding: 0;
+              border-radius: 0;
+              color: inherit;
+              font-size: inherit;
+              background-color: transparent;
+              box-shadow: none;
+              border: none;
+              font-weight: 400;
+              font-size: inherit;
+              line-height: inherit;
+              color: #20588f;
+              box-shadow: inset 0 -1px;
+              display: -webkit-inline-box;
+              display: -webkit-inline-flex;
+              display: -ms-inline-flexbox;
+              display: inline-flex;
+              -webkit-align-items: center;
+              -webkit-box-align: center;
+              -ms-flex-align: center;
+              align-items: center;
+              -webkit-box-pack: center;
+              -webkit-justify-content: center;
+              -ms-flex-pack: center;
+              justify-content: center;
+              padding-left: 13px;
+              padding-right: 13px;
+              font-size: 16px;
+              font-size: 0.8888888888888888rem;
+              line-height: 1.625;
+              min-height: 40px;
+              box-shadow: none;
+              padding-left: 0;
+              padding-right: 4px;
+              min-height: 32.5px;
+              font-size: 16px;
+              font-size: 0.8888888888888888rem;
+              line-height: 25px;
+              -webkit-flex: 0 0 auto;
+              -ms-flex: 0 0 auto;
+              flex: 0 0 auto;
+            }
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:hover,
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+              color: white;
+              background-color: #184673;
+              border: 2px solid #184673;
+            }
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton[disabled] {
+              color: #777777;
+              background-color: #e6e6e6;
+              border-color: transparent;
+              cursor: not-allowed;
+            }
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+              box-shadow: 0 0 2px #20588f;
+            }
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:hover,
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:active,
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:disabled,
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+              box-shadow: none;
+              color: #20588f;
+              background-color: transparent;
+              border: none;
+            }
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+              outline-width: medium;
+            }
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:hover,
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+              box-shadow: none;
+            }
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:hover,
+            .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+              box-shadow: inset 0 -1px;
+            }</style
+          ><button
+            type=\\"button\\"
+            data-audio-text-button-id=\\"static-render-1\\"
+            class=\\"e1wmpntw10 css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton e1ljv5qk0\\"
+          >
+            Tekstversjon
+          </button>
+        </div>
+      </div>
+    </div>
     <div
       data-audio-player=\\"1\\"
       data-src=\\"http://audio.no/file/voof.mp3\\"
@@ -705,6 +885,221 @@ exports[`replacer/replaceEmbedsInHtml replace audio embeds 1`] = `
           </div>
         </div>
       </div>
+    </div>
+    <style data-emotion-css=\\"dk8xs8-TextVersionWrapper\\">
+      .css-dk8xs8-TextVersionWrapper {
+        border: 1px solid #deebf6;
+        border-top: 0;
+        font-size: 16px;
+        font-size: 0.8888888888888888rem;
+        line-height: 30px;
+        font-family: \\"Source Sans Pro\\", Helvetica, Arial, STKaiti, \\"华文楷体\\",
+          KaiTi, SimKai, \\"楷体\\", KaiU, DFKai-SB, \\"標楷體\\", SongTi, \\"宋体\\",
+          sans-serif;
+        padding: 26px 13px 13px;
+      }
+      .css-dk8xs8-TextVersionWrapper.audio-player-text-version-hidden {
+        display: none;
+      }
+      @media (min-width: 37.5625em) {
+        .css-dk8xs8-TextVersionWrapper {
+          padding: 26px;
+        }
+      }
+      @media (min-width: 48em) {
+        .css-dk8xs8-TextVersionWrapper {
+          padding: 26px 32.5px;
+        }
+      }
+    </style>
+    <div
+      id=\\"static-render-1\\"
+      hidden
+      class=\\"css-dk8xs8-TextVersionWrapper e1wmpntw7\\"
+    >
+      <style data-emotion-css=\\"asynmz-TextVersionHeadingWrapper\\">
+        .css-asynmz-TextVersionHeadingWrapper {
+          display: -webkit-box;
+          display: -webkit-flex;
+          display: -ms-flexbox;
+          display: flex;
+          -webkit-box-pack: justify;
+          -webkit-justify-content: space-between;
+          -ms-flex-pack: justify;
+          justify-content: space-between;
+          -webkit-align-items: flex-start;
+          -webkit-box-align: flex-start;
+          -ms-flex-align: flex-start;
+          align-items: flex-start;
+        }
+      </style>
+      <div class=\\"css-asynmz-TextVersionHeadingWrapper e1wmpntw8\\">
+        <style data-emotion-css=\\"1tcndwb-TextVersionHeading\\">
+          .css-1tcndwb-TextVersionHeading {
+            font-weight: 600;
+            margin: 13px 0 26px;
+          }
+        </style>
+        <h2 class=\\"css-1tcndwb-TextVersionHeading e1wmpntw9\\">Tekstversjon</h2>
+        <style data-emotion-css=\\"2bx46a-LinkButton\\">
+          .css-2bx46a-LinkButton {
+            box-shadow: none;
+            padding-left: 0;
+            padding-right: 4px;
+            min-height: 32.5px;
+            font-size: 16px;
+            font-size: 0.8888888888888888rem;
+            line-height: 25px;
+            -webkit-flex: 0 0 auto;
+            -ms-flex: 0 0 auto;
+            flex: 0 0 auto;
+          }
+          .css-2bx46a-LinkButton:hover,
+          .css-2bx46a-LinkButton:focus {
+            box-shadow: inset 0 -1px;
+          }</style
+        ><style
+          data-emotion-css=\\"f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton\\"
+        >
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton {
+            display: inline-block;
+            color: #ffffff;
+            background-color: #20588f;
+            border: 2px solid #20588f;
+            border-radius: 4px;
+            padding: 4px 13px;
+            outline-width: 0;
+            cursor: pointer;
+            -webkit-text-decoration: none;
+            text-decoration: none;
+            font-size: 16px;
+            font-size: 0.8888888888888888rem;
+            line-height: 1.625;
+            font-family: \\"Source Sans Pro\\", Helvetica, Arial, STKaiti,
+              \\"华文楷体\\", KaiTi, SimKai, \\"楷体\\", KaiU, DFKai-SB, \\"標楷體\\",
+              SongTi, \\"宋体\\", sans-serif;
+            font-weight: 700;
+            -webkit-transition: all 0.2s cubic-bezier(0.17, 0.04, 0.03, 0.94);
+            transition: all 0.2s cubic-bezier(0.17, 0.04, 0.03, 0.94);
+            box-shadow: none;
+            text-align: center;
+            -webkit-transition: background-color none;
+            transition: background-color none;
+            padding: 0;
+            border-radius: 0;
+            color: inherit;
+            font-size: inherit;
+            background-color: transparent;
+            box-shadow: none;
+            border: none;
+            font-weight: 400;
+            font-size: inherit;
+            line-height: inherit;
+            color: #20588f;
+            box-shadow: inset 0 -1px;
+            display: -webkit-inline-box;
+            display: -webkit-inline-flex;
+            display: -ms-inline-flexbox;
+            display: inline-flex;
+            -webkit-align-items: center;
+            -webkit-box-align: center;
+            -ms-flex-align: center;
+            align-items: center;
+            -webkit-box-pack: center;
+            -webkit-justify-content: center;
+            -ms-flex-pack: center;
+            justify-content: center;
+            padding-left: 13px;
+            padding-right: 13px;
+            font-size: 16px;
+            font-size: 0.8888888888888888rem;
+            line-height: 1.625;
+            min-height: 40px;
+            box-shadow: none;
+            padding-left: 0;
+            padding-right: 4px;
+            min-height: 32.5px;
+            font-size: 16px;
+            font-size: 0.8888888888888888rem;
+            line-height: 25px;
+            -webkit-flex: 0 0 auto;
+            -ms-flex: 0 0 auto;
+            flex: 0 0 auto;
+          }
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:hover,
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+            color: white;
+            background-color: #184673;
+            border: 2px solid #184673;
+          }
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton[disabled] {
+            color: #777777;
+            background-color: #e6e6e6;
+            border-color: transparent;
+            cursor: not-allowed;
+          }
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+            box-shadow: 0 0 2px #20588f;
+          }
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:hover,
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:active,
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:disabled,
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+            box-shadow: none;
+            color: #20588f;
+            background-color: transparent;
+            border: none;
+          }
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+            outline-width: medium;
+          }
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:hover,
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+            box-shadow: none;
+          }
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:hover,
+          .css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton:focus {
+            box-shadow: inset 0 -1px;
+          }</style
+        ><button
+          type=\\"button\\"
+          data-audio-text-button-id=\\"static-render-1\\"
+          class=\\"e1wmpntw10 css-f4yp6j-StyledButton-buttonStyle-strippedStyle-link-normal-ButtonStyles-LinkButton e1ljv5qk0\\"
+        >
+          <svg
+            fill=\\"currentColor\\"
+            preserveAspectRatio=\\"xMidYMid meet\\"
+            height=\\"1em\\"
+            width=\\"1em\\"
+            class=\\"c-icon\\"
+            viewBox=\\"0 0 24 24\\"
+            data-license=\\"Apache License 2.0\\"
+            data-source=\\"Material Design\\"
+            style=\\"vertical-align:middle;width:20px;height:20px\\"
+          >
+            <title>Cross</title>
+            <g>
+              <path
+                d=\\"M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z\\"
+              />
+              <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\" />
+            </g></svg
+          ><style data-emotion-css=\\"1r04ljq-CloseText\\">
+            .css-1r04ljq-CloseText {
+              display: inline-block;
+              margin-left: 6.5px;
+            }</style
+          ><span class=\\"css-1r04ljq-CloseText e1wmpntw11\\"
+            >Lukk tekstversjon</span
+          >
+        </button>
+      </div>
+      <style data-emotion-css=\\"1x3m1w3-TextVersionText\\">
+        .css-1x3m1w3-TextVersionText {
+          max-width: 670px;
+        }
+      </style>
+      <div class=\\"css-1x3m1w3-TextVersionText e1wmpntw12\\"><span></span></div>
     </div>
     <figcaption class=\\"c-figure__caption\\">
       <div class=\\"c-figure__info\\">Caption 1</div>

--- a/src/plugins/audioPlugin.js
+++ b/src/plugins/audioPlugin.js
@@ -90,11 +90,17 @@ export default function createAudioPlugin() {
       id,
       title: { title },
       audioFile: { mimeType, url },
+      podcastMeta,
       copyright: {
         license: { license: licenseAbbreviation },
         origin,
       },
     } = audio;
+
+    const { introduction: description, manuscript: textVersion, coverPhoto } =
+      podcastMeta || {};
+
+    const img = coverPhoto && { url: coverPhoto.url, alt: coverPhoto.altText };
 
     const caption = data.caption || title;
 
@@ -124,8 +130,14 @@ export default function createAudioPlugin() {
       data.type === 'minimal' ? (
         <AudioPlayer speech type={mimeType} src={url} title={title} />
       ) : (
-        <Figure id={figureid} type="full-column">
-          <AudioPlayer src={url} title={title} />
+        <Figure id={figureid} type="full">
+          <AudioPlayer
+            description={description}
+            img={img}
+            src={url}
+            textVersion={textVersion}
+            title={title}
+          />
           <FigureCaption
             figureId={figureid}
             id={figureLicenseDialogId}

--- a/src/plugins/audioPlugin.js
+++ b/src/plugins/audioPlugin.js
@@ -7,6 +7,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Remarkable } from 'remarkable';
 import {
   Figure,
   FigureLicenseDialog,
@@ -38,6 +39,12 @@ export default function createAudioPlugin() {
         src: audio.audioFile.url,
       };
     }
+  };
+
+  const renderMarkdown = text => {
+    const md = new Remarkable();
+    const rendered = md.render(text);
+    return <span dangerouslySetInnerHTML={{ __html: rendered }} />;
   };
 
   const onError = ({ audio }, locale) => {
@@ -97,8 +104,10 @@ export default function createAudioPlugin() {
       },
     } = audio;
 
-    const { introduction: description, manuscript: textVersion, coverPhoto } =
-      podcastMeta || {};
+    const { introduction, manuscript, coverPhoto } = podcastMeta || {};
+
+    const textVersion = renderMarkdown(manuscript);
+    const description = renderMarkdown(introduction);
 
     const img = coverPhoto && { url: coverPhoto.url, alt: coverPhoto.altText };
 
@@ -137,6 +146,7 @@ export default function createAudioPlugin() {
             src={url}
             textVersion={textVersion}
             title={title}
+            staticRenderId={`static-render-${id}`}
           />
           <FigureCaption
             figureId={figureid}

--- a/src/plugins/audioPlugin.js
+++ b/src/plugins/audioPlugin.js
@@ -146,7 +146,7 @@ export default function createAudioPlugin() {
             src={url}
             textVersion={textVersion}
             title={title}
-            staticRenderId={`static-render-${id}`}
+            staticRenderId={`static-render-${id}-${locale}`}
           />
           <FigureCaption
             figureId={figureid}


### PR DESCRIPTION
Viser podcastfelt i audio. Gjør audio til størrelse full for at den skal bli like brei som bilder og i ed.

Test:
Må kjøres lokalt sammen med ed som må kjøres med start-with-local-converter.
http://localhost:3000/preview/30642/nb skal vises med podcastnformasjon.