### PR TITLE
Converts youtube http-adresses to https

### DIFF
--- a/src/api/__tests__/__snapshots__/oembedProxyApi-test.js.snap
+++ b/src/api/__tests__/__snapshots__/oembedProxyApi-test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Converts youtube http-url to https 1`] = `
+Object {
+  "data": Object {
+    "url": "https://youtube.com/videoid",
+  },
+  "oembed": Object {
+    "html": "<iframe src=\\"https://youtube.com/videoid\\"></iframe>",
+  },
+}
+`;
+
+exports[`Leaves youtube https-url be 1`] = `
+Object {
+  "data": Object {
+    "url": "https://youtube.com/anotherid",
+  },
+  "oembed": Object {
+    "html": "<iframe src=\\"https://youtube.com/anotherid\\"></iframe>",
+  },
+}
+`;

--- a/src/api/__tests__/brightcove-test.js
+++ b/src/api/__tests__/brightcove-test.js
@@ -1,6 +1,14 @@
+/**
+ * Copyright (c) 2018-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import { getContributorGroups } from '../brightcove';
 
-test('parses contributor string correctly', () => {
+test('parses contributor string correctly', async () => {
   const fields = {
     licenseinfo: 'Opphaver: Senter for nye medier, Høgskolen i Bergen',
     licenseinfo1: 'Opphaver:Adalia film & media',

--- a/src/api/__tests__/brightcove-test.js
+++ b/src/api/__tests__/brightcove-test.js
@@ -8,7 +8,7 @@
 
 import { getContributorGroups } from '../brightcove';
 
-test('parses contributor string correctly', async () => {
+test('parses contributor string correctly', () => {
   const fields = {
     licenseinfo: 'Opphaver: Senter for nye medier, Høgskolen i Bergen',
     licenseinfo1: 'Opphaver:Adalia film & media',

--- a/src/api/__tests__/oembedProxyApi-test.js
+++ b/src/api/__tests__/oembedProxyApi-test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import nock from 'nock';
+import { fetchOembed } from '../oembedProxyApi';
+
+test('Converts youtube http-url to https', async () => {
+  nock('http://ndla-api')
+    .get('/oembed-proxy/v1/oembed?url=https://youtube.com/videoid')
+    .reply(200, {
+      html: '<iframe src="https://youtube.com/videoid"></iframe>',
+    });
+
+  const oembed = {
+    data: {
+      url: 'http://youtube.com/videoid',
+    },
+  };
+  const result = await fetchOembed(oembed);
+  expect(result).toMatchSnapshot();
+});
+
+test('Leaves youtube https-url be', async () => {
+  nock('http://ndla-api')
+    .get('/oembed-proxy/v1/oembed?url=https://youtube.com/anotherid')
+    .reply(200, {
+      html: '<iframe src="https://youtube.com/anotherid"></iframe>',
+    });
+
+  const oembed = {
+    data: {
+      url: 'https://youtube.com/anotherid',
+    },
+  };
+  const result = await fetchOembed(oembed);
+  expect(result).toMatchSnapshot();
+});

--- a/src/api/oembedProxyApi.js
+++ b/src/api/oembedProxyApi.js
@@ -15,6 +15,11 @@ import {
 } from '../utils/apiHelpers';
 
 export const fetchOembed = async (embed, accessToken, options = {}) => {
+  const url = new URL(embed.data.url);
+  if (url.hostname.includes('youtu') && url.protocol === 'http:') {
+    url.protocol = 'https:';
+    embed.data.url = url.href;
+  }
   const response = await fetch(
     apiResourceUrl(
       `/oembed-proxy/v1/oembed?${queryString.stringify({


### PR DESCRIPTION
Yotube-adresser som er lagra med http vises greit i ed, men ikkje i frontend. Det er fordi oembed-tjenesten til youtube har slutta å godta http-adresser.