### PR TITLE
License endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,6 +29,8 @@ swaggerSpec.paths['/article-converter/json/{language}/{article_id}:'] =
   swaggerRoutes.getJsonArticle;
 swaggerSpec.paths['/article-converter/html/{language}/{article_id}:'] =
   swaggerRoutes.getHtmlArticle;
+swaggerSpec.paths['/article-converter/json/{language}/meta-data'] =
+  swaggerRoutes.getMetaData;
 swaggerSpec.paths['/article-converter/json/{language}/transform-article:'] =
   swaggerRoutes.postJsonTransformArticle;
 

--- a/src/fetchEmbedMetaData.js
+++ b/src/fetchEmbedMetaData.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import cheerio from 'cheerio';
+import { getEmbedsFromHtml } from './parser';
+import { getEmbedsResources } from './transformers';
+import getEmbedMetaData from './getEmbedMetaData';
+
+export default async function fetchEmbedMetaData(embedTag) {
+  const embeds = await getEmbedsFromHtml(cheerio.load(embedTag));
+  const embedsWithResources = await getEmbedsResources(embeds);
+  return getEmbedMetaData(embedsWithResources);
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,7 +25,9 @@ module.exports.setup = function routes(app) {
     const lang = getHtmlLang(defined(req.params.lang, ''));
     fetchEmbedMetaData(embed, accessToken, lang)
       .then(data => {
-        res.json(data);
+        res.json({
+          metaData: data,
+        });
       })
       .catch(error => {
         log.error(error);

--- a/src/routes.js
+++ b/src/routes.js
@@ -10,6 +10,7 @@ import defined from 'defined';
 import fetchAndTransformArticle, {
   transformArticle,
 } from './fetchAndTransformArticle';
+import fetchEmbedMetaData from './fetchEmbedMetaData';
 import { htmlTemplate, htmlErrorTemplate } from './utils/htmlTemplates';
 import { getHtmlLang } from './locale/configureLocale';
 import { getAppropriateErrorResponse } from './utils/errorHelpers';
@@ -76,6 +77,24 @@ module.exports.setup = function routes(app) {
           config.isProduction
         );
         res.status(response.status).send(htmlErrorTemplate(lang, response));
+      });
+  });
+
+  app.get('/article-converter/json/meta-data', (req, res) => {
+    const embed = req.query.embed;
+    const accessToken = req.headers.authorization;
+    const lang = getHtmlLang(defined(req.params.lang, ''));
+    fetchEmbedMetaData(embed, accessToken, lang)
+      .then(data => {
+        res.json(data);
+      })
+      .catch(error => {
+        log.error(error);
+        const response = getAppropriateErrorResponse(
+          error,
+          config.isProduction
+        );
+        res.status(response.status).json(response);
       });
   });
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -19,6 +19,24 @@ import log from './utils/logger';
 
 // Sets up the routes.
 module.exports.setup = function routes(app) {
+  app.get('/article-converter/json/:lang/meta-data', (req, res) => {
+    const embed = req.query.embed;
+    const accessToken = req.headers.authorization;
+    const lang = getHtmlLang(defined(req.params.lang, ''));
+    fetchEmbedMetaData(embed, accessToken, lang)
+      .then(data => {
+        res.json(data);
+      })
+      .catch(error => {
+        log.error(error);
+        const response = getAppropriateErrorResponse(
+          error,
+          config.isProduction
+        );
+        res.status(response.status).json(response);
+      });
+  });
+
   app.get('/article-converter/raw/:lang/:id', (req, res) => {
     const url = req.url.replace('raw', 'json');
     res.redirect(url);
@@ -77,24 +95,6 @@ module.exports.setup = function routes(app) {
           config.isProduction
         );
         res.status(response.status).send(htmlErrorTemplate(lang, response));
-      });
-  });
-
-  app.get('/article-converter/json/meta-data', (req, res) => {
-    const embed = req.query.embed;
-    const accessToken = req.headers.authorization;
-    const lang = getHtmlLang(defined(req.params.lang, ''));
-    fetchEmbedMetaData(embed, accessToken, lang)
-      .then(data => {
-        res.json(data);
-      })
-      .catch(error => {
-        log.error(error);
-        const response = getAppropriateErrorResponse(
-          error,
-          config.isProduction
-        );
-        res.status(response.status).json(response);
       });
   });
 

--- a/src/swagger/swagger.yaml
+++ b/src/swagger/swagger.yaml
@@ -12,7 +12,7 @@ definitions:
     content:
       content: string
       language: string
-      exmaple: "<section>some text</section>"
+      exmaple: '<section>some text</section>'
     title:
       title: string
       language: string
@@ -90,3 +90,41 @@ definitions:
               type: string
               description: Rightholders name
               example: John Doe
+  h5p:
+    type: object
+    description: H5P attributes
+    properties:
+      title:
+        type: string
+        description: H5P title
+        example: Foo
+      license:
+        type: string
+        description: License short name
+        example: CC BY-SA
+      licenseVersion:
+        type: string
+        description: License version
+        example: 4.0
+      thumbnail:
+        type: string
+        description: Thumbnail URL
+        example: https://test.api.ndla.no/image-api/raw/tacf8f02.jpg
+      contentType:
+        type: string
+        description: Content type
+        example: Image
+      authors:
+        type: array
+        description: Authors
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Author name
+              example: John Doe
+            type:
+              type: string
+              description: Author type
+              example: Author

--- a/src/swagger/swagger.yaml
+++ b/src/swagger/swagger.yaml
@@ -12,7 +12,7 @@ definitions:
     content:
       content: string
       language: string
-      exmaple: '<section>some text</section>'
+      example: '<section>some text</section>'
     title:
       title: string
       language: string

--- a/src/swagger/swaggerRoutes.js
+++ b/src/swagger/swaggerRoutes.js
@@ -252,6 +252,180 @@ module.exports = {
       },
     },
   },
+  getMetaData: {
+    get: {
+      summary: 'Returns meta data of embeds',
+      produces: ['application/json'],
+      parameters: [
+        {
+          in: 'path',
+          name: 'language',
+          description: 'The ISO 639-1 language code describing language.',
+          required: true,
+          type: 'string',
+        },
+        {
+          $ref: '#/parameters/authorizationHeader',
+        },
+        {
+          in: 'query',
+          name: 'embed',
+          description: 'Embed tags to fetch meta data for',
+          required: true,
+          type: 'string',
+        },
+      ],
+      security: [
+        {
+          oauth2: [],
+        },
+      ],
+      responses: {
+        '200': {
+          description: 'OK',
+          schema: {
+            type: 'object',
+            properties: {
+              images: {
+                type: 'array',
+                description: 'Array of meta data images.',
+                items: {
+                  type: 'object',
+                  properties: {
+                    title: {
+                      type: 'string',
+                      description: 'Meta image title',
+                      example: 'Foo',
+                    },
+                    altText: {
+                      type: 'string',
+                      description: 'Meta image alt text',
+                      example: 'Bar',
+                    },
+                    copyright: {
+                      $ref: '#/definitions/copyright',
+                    },
+                    src: {
+                      type: 'string',
+                      description: 'Meta image src',
+                      example:
+                        'https://test.api.ndla.no/image-api/raw/tacf8f02.jpg',
+                    },
+                  },
+                },
+              },
+              h5ps: {
+                type: 'array',
+                description: 'Array of meta data h5ps',
+                items: {
+                  type: 'object',
+                  description: 'H5P object',
+                  properties: {
+                    h5p: {
+                      $ref: '#/definitions/h5p',
+                    },
+                    assets: {
+                      type: 'array',
+                      description: 'Array of assets used in the h5p',
+                      items: {
+                        $ref: '#/definitions/h5p',
+                      },
+                    },
+                    h5pLibrary: {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'string',
+                          description: 'H5P library name',
+                          example: 'Foo',
+                        },
+                        majorVersion: {
+                          type: 'integer',
+                          description: 'Major version',
+                          example: 1,
+                        },
+                        mainorVersion: {
+                          type: 'integer',
+                          description: 'Minor version',
+                          example: 7,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              brightcoves: {
+                type: 'array',
+                description: 'Array of meta data brightcove videos',
+                items: {
+                  type: 'object',
+                  properties: {
+                    title: {
+                      type: 'string',
+                      description: 'Video title',
+                      example: 'Foo',
+                    },
+                    description: {
+                      type: 'string',
+                      description: 'Video description',
+                      example: 'Foo',
+                    },
+                    copyright: {
+                      $ref: '#/definitions/copyright',
+                    },
+                    cover: {
+                      type: 'string',
+                      description: 'Cover image url',
+                      example:
+                        'https://test.api.ndla.no/image-api/raw/tacf8f02.jpg',
+                    },
+                    src: {
+                      type: 'string',
+                      description: 'Video source url',
+                      example:
+                        'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6206610074001',
+                    },
+                    iframe: {
+                      type: 'object',
+                      properties: {
+                        src: {
+                          type: 'string',
+                          description: 'Iframe source url',
+                          example:
+                            'https://players.brightcove.net/4806596774001/BkLm8fT_default/index.html?videoId=6206610074001',
+                        },
+                        height: {
+                          type: 'integer',
+                          description: 'Iframe height',
+                          example: 720,
+                        },
+                        width: {
+                          type: 'integer',
+                          description: 'Iframe width',
+                          example: 1280,
+                        },
+                      },
+                    },
+                    uploadDate: {
+                      type: 'string',
+                      description: 'Upload date',
+                      example: '2020-11-03T07:49:16.299Z',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '401': {
+          description: 'Unauthorized',
+        },
+        '404': {
+          description: 'Not found',
+        },
+      },
+    },
+  },
   postJsonTransformArticle: {
     post: {
       summary:

--- a/src/transformers.js
+++ b/src/transformers.js
@@ -33,20 +33,8 @@ async function executeHtmlTransforms(content, lang, options) {
   );
 }
 
-export async function transform(
-  content,
-  lang,
-  accessToken,
-  visualElement,
-  options
-) {
-  if (visualElement && visualElement.visualElement) {
-    content('body').prepend(
-      `<section>${visualElement.visualElement}</section>`
-    );
-  }
-  const embeds = await getEmbedsFromHtml(content, { transform, ...options });
-  const embedsWithResources = await Promise.all(
+export async function getEmbedsResources(embeds, accessToken, lang) {
+  return Promise.all(
     embeds.map(async embed => {
       const plugin = embed.plugin;
       if (plugin && plugin.fetchResource) {
@@ -72,6 +60,26 @@ export async function transform(
       }
       return embed;
     })
+  );
+}
+
+export async function transform(
+  content,
+  lang,
+  accessToken,
+  visualElement,
+  options
+) {
+  if (visualElement && visualElement.visualElement) {
+    content('body').prepend(
+      `<section>${visualElement.visualElement}</section>`
+    );
+  }
+  const embeds = await getEmbedsFromHtml(content, { transform, ...options });
+  const embedsWithResources = await getEmbedsResources(
+    embeds,
+    accessToken,
+    lang
   );
   await replaceEmbedsInHtml(embedsWithResources, lang);
   const embedMetaData = getEmbedMetaData(embedsWithResources, lang);


### PR DESCRIPTION
Legger til et nytt endepunkt: `/article-converter/json/:lang/meta-data` for å hente h5p og brightcove metadata