### PR TITLE
I tilfelle feil i type fra brightcove

### DIFF
--- a/src/api/__tests__/__snapshots__/brightcove-test.js.snap
+++ b/src/api/__tests__/__snapshots__/brightcove-test.js.snap
@@ -45,6 +45,10 @@ Object {
       "name": "Lucasfilm",
       "type": "",
     },
+    Object {
+      "name": "Feil Type",
+      "type": "",
+    },
   ],
   "processors": Array [],
   "rightsholders": Array [],

--- a/src/api/__tests__/brightcove-test.js
+++ b/src/api/__tests__/brightcove-test.js
@@ -28,6 +28,7 @@ test('uses fallback if contributor string could not be parsed', () => {
     licenseinfo1: 'Opphavsmann Adalia film & media',
     licenseinfo2: ' Opphavsmann: Adalia film & media',
     licenseinfo3: 'Produsent: Lucasfilm',
+    licenseinfo4: 'Ophavsmann: Feil Type',
     yt_privacy_status: 'private',
     license: 'Navngivelse-Del på samme vilkår',
   };

--- a/src/plugins/__tests__/__snapshots__/pluginHelpers-test.js.snap
+++ b/src/plugins/__tests__/__snapshots__/pluginHelpers-test.js.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getCopyString from brightcove with missing type due to typo 1`] = `": Video Kunstner. Title [Internett]. Forlag: Scanpix. Hentet fra: https://test.ndla.no/article/123 Lest: 19.05.2021"`;
+
+exports[`getCopyString from image with all properties 1`] = `"Fotograf: Foto Graf. Bearbeider: Bear Beider. Title [Internett]. Forlag: Scanpix. Hentet fra: http://api.ndla.no/image/raw/1 Lest: 19.05.2021"`;
+
 exports[`makeIframe 1`] = `"<figure class=\\"c-figure c-figure--resize\\" resizeIframe><iframe title=\\"https://youtube.com\\" aria-label=\\"https://youtube.com\\" src=\\"https://youtube.com\\" width=\\"400\\" height=\\"600\\" allowfullscreen scrolling=\\"no\\" frameborder=\\"0\\" loading=\\"lazy\\"></iframe></figure>"`;
 
 exports[`makeIframe 2`] = `"<figure class=\\"c-figure c-figure--resize\\" resizeIframe><iframe title=\\"https://youtube.com\\" aria-label=\\"https://youtube.com\\" src=\\"https://youtube.com\\" width=\\"400\\" height=\\"600\\" allowfullscreen scrolling=\\"no\\" frameborder=\\"0\\" loading=\\"lazy\\"></iframe></figure>"`;

--- a/src/plugins/__tests__/pluginHelpers-test.js
+++ b/src/plugins/__tests__/pluginHelpers-test.js
@@ -6,7 +6,7 @@
  *
  */
 
-import { makeIframe, wrapInFigure } from '../pluginHelpers';
+import { getCopyString, makeIframe, wrapInFigure } from '../pluginHelpers';
 
 test('wrapInFigure', () => {
   expect(wrapInFigure('<div></div>')).toMatchSnapshot();
@@ -21,5 +21,34 @@ test('makeIframe', () => {
   ).toMatchSnapshot();
   expect(
     makeIframe('https://youtube.com', '400 px', '600 px', 'Youtube')
+  ).toMatchSnapshot();
+});
+
+test('getCopyString from image with all properties', () => {
+  const copyright = {
+    license: 'CC-BY-SA-4.0',
+    creators: [{ type: 'photographer', name: 'Foto Graf' }],
+    rightsholders: [{ type: 'publisher', name: 'Scanpix' }],
+    processors: [{ type: 'processor', name: 'Bear Beider' }],
+  };
+  expect(
+    getCopyString(
+      'Title',
+      'http://api.ndla.no/image/raw/1',
+      undefined,
+      copyright,
+      'nb'
+    )
+  ).toMatchSnapshot();
+});
+
+test('getCopyString from brightcove with missing type due to typo', () => {
+  const copyright = {
+    license: 'CC-BY-SA-4.0',
+    creators: [{ type: '', name: 'Video Kunstner' }],
+    rightsholders: [{ type: 'publisher', name: 'Scanpix' }],
+  };
+  expect(
+    getCopyString('Title', undefined, '/article/123', copyright, 'nb')
   ).toMatchSnapshot();
 });

--- a/src/plugins/pluginHelpers.js
+++ b/src/plugins/pluginHelpers.js
@@ -45,7 +45,7 @@ const makeCreditCopyString = (roles, locale) => {
   return (
     roles
       .map(creator => {
-        const type = t(locale, `${creator.type.toLowerCase()}`);
+        const type = creator.type && t(locale, `${creator.type.toLowerCase()}`);
         return `${type}: ${creator.name.trim()}`;
       })
       .join(', ') + '. '

--- a/src/plugins/pluginHelpers.js
+++ b/src/plugins/pluginHelpers.js
@@ -95,9 +95,9 @@ export const getCopyString = (title, src, path, copyright, locale) => {
 
 export const getLicenseCredits = copyright => {
   return {
-    creators: copyright.creators?.length > 0 ? copyright.creators : [],
+    creators: copyright?.creators?.length > 0 ? copyright.creators : [],
     rightsholders:
-      copyright.rightsholders?.length > 0 ? copyright.rightsholders : [],
-    processors: copyright.processors?.length > 0 ? copyright.processors : [],
+      copyright?.rightsholders?.length > 0 ? copyright.rightsholders : [],
+    processors: copyright?.processors?.length > 0 ? copyright.processors : [],
   };
 };


### PR DESCRIPTION
Lisensinformasjon i brightcove er registrert manuellt og dermed sårbart for skrivefeil. Eksisterende kode knekker dersom en video har fått info: `Ophavsmann: Fornavn Etternavn`. Endringa tar høgde for at type bearbeider er tom. Det er ikkje ideellt at teksten då vil bli `: Fornavn Etternavn` men det er et signal om at noko ikkje er som det skal være.