### PR TITLE
Always return content for standard

### DIFF
--- a/src/fetchAndTransformArticle.js
+++ b/src/fetchAndTransformArticle.js
@@ -25,7 +25,7 @@ export async function transformArticle(
     article.copyright,
     lang
   );
-  const hasContent = cheerio.load(html).text() !== '';
+  const hasContent = article.articleType === 'standard' || cheerio.load(html).text() !== '';
 
   return {
     ...article,

--- a/src/fetchAndTransformArticle.js
+++ b/src/fetchAndTransformArticle.js
@@ -25,7 +25,8 @@ export async function transformArticle(
     article.copyright,
     lang
   );
-  const hasContent = article.articleType === 'standard' || cheerio.load(html).text() !== '';
+  const hasContent =
+    article.articleType === 'standard' || cheerio.load(html).text() !== '';
 
   return {
     ...article,


### PR DESCRIPTION
Grensetilfelle, men ressursartikler som kun har en embed bør vises uansett om den ikkje har tekst.

Test:
* Kjør branch lokalt med yarn start
* Kjør ed lokalt med `yarn start-with-local-converter`
* Forhåndsvis en ressurs som kun har embeds i seg.