### PR TITLE
Filtering old topics with no path.

### DIFF
--- a/src/api/taxonomyApi.js
+++ b/src/api/taxonomyApi.js
@@ -59,9 +59,11 @@ export async function fetchArticleResource(
     contentType
   );
 
-  if (topics[0]) {
+  const withPath = topics.filter(t => t.path !== null);
+
+  if (withPath[0]) {
     // Add resourceType so that content type is correct
-    return { ...topics[0], resourceTypes: [{ id: 'subject' }] };
+    return { ...withPath[0], resourceTypes: [{ id: 'subject' }] };
   }
   return undefined;
 }


### PR DESCRIPTION
Lenke til artikkel uten kontekst vises fordi det ligger en gammel topic i basen som ikkje har path. Slike topics trengs for at redirect skal fungere.

i prod:  https://ndla.no/subject:1:058bdbdb-aa5a-4a29-88fb-45e664999417/topic:1:0c9ce0dc-3863-4e03-a2df-a1480a4e929c/topic:1:94ceef85-9325-4c6b-82fb-2434ce5e2817/resource:e3358cde-7cc3-48ca-b2a9-65a64910bd53

Test
* http://localhost:3100/article-converter/html/nb/28046 skal ha en taksonomiurl under lenka Verktøykassa.