### PR TITLE
Do not resize trinket embeds

### DIFF
--- a/src/__tests__/__snapshots__/replacer-test.js.snap
+++ b/src/__tests__/__snapshots__/replacer-test.js.snap
@@ -4882,6 +4882,25 @@ exports[`replacer/replaceEmbedsInHtml replace ndla-filmiundervisning embeds 1`] 
 "
 `;
 
+exports[`replacer/replaceEmbedsInHtml replace trinket embeds without resize 1`] = `
+"<section>
+  <figure class=\\"c-figure\\">
+    <iframe
+      title=\\"https://trinket.io/python/asdfesafadc\\"
+      aria-label=\\"https://trinket.io/python/asdfesafadc\\"
+      src=\\"https://trinket.io/python/asdfesafadc\\"
+      width=\\"777\\"
+      height=\\"700\\"
+      allowfullscreen
+      scrolling=\\"no\\"
+      frameborder=\\"0\\"
+      loading=\\"lazy\\"
+    ></iframe>
+  </figure>
+</section>
+"
+`;
+
 exports[`replacer/replaceEmbedsInHtml replace various emdeds in html 1`] = `
 "<section>
   <figure data-sizetype=\\"full\\" class=\\"c-figure u-float-full\\" id=\\"figure-1326\\">

--- a/src/__tests__/replacer-test.js
+++ b/src/__tests__/replacer-test.js
@@ -438,3 +438,22 @@ test('replacer/replaceEmbedsInHtml replace footnote embeds', async () => {
   expect(getEmbedMetaData(embeds)).toMatchSnapshot();
   expect(prettify(replaced)).toMatchSnapshot();
 });
+
+test('replacer/replaceEmbedsInHtml replace trinket embeds without resize', async () => {
+  const articleContent = cheerio.load(
+    '<section><embed data-resource="iframe" data-url="https://trinket.io/python/asdfesafadc" data-width="777" data-height="700"/></section>'
+  );
+
+  const embeds = [
+    {
+      embed: articleContent('embed[data-resource="iframe"]'),
+      data: articleContent('embed[data-resource="iframe"]').data(),
+      plugin: createIframePlugin(),
+    },
+  ];
+
+  await replaceEmbedsInHtml(embeds, 'nb');
+  const replaced = articleContent('body').html();
+
+  expect(prettify(replaced)).toMatchSnapshot();
+});

--- a/src/plugins/iframePlugin.js
+++ b/src/plugins/iframePlugin.js
@@ -11,7 +11,8 @@ import { makeIframe } from './pluginHelpers';
 export default function createIframePlugin() {
   const embedToHTML = embed => {
     const { url, width, height } = embed.data;
-    return makeIframe(url, width, height);
+    const resize = url.includes('trinket.io') ? false : true;
+    return makeIframe(url, width, height, '', resize);
   };
 
   return {


### PR DESCRIPTION
Så lenge trinket-embeds har høgde 700, som spesifisert i ed, vises ikkje footer fra embed-sida. Ved å ikkje sette resize på figure så endres ikkje størrelsen på iframen i articlescripts. Føles litt hacky men fungerer når eg tester lokalt.

Test:
* Sjekk ut branch og kjør lokalt
* Start ed med `yarn start-with-local-converter`
* Embeds med trinket.io skal vises med samme høgde som i ed.

Merk, dersom høgde på lagra embed endres i html-koden vil ikkje dette fungere like bra.