### PR TITLE
Sjekker om embed-url for bilder slutter på et tall.

### DIFF
--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -7,11 +7,13 @@
  */
 
 import fetch from 'isomorphic-fetch';
+import { isNumber } from 'lodash';
 import {
   headerWithAccessToken,
   resolveJsonOrRejectWithError,
   convertToInternalUrlIfPossible,
 } from '../utils/apiHelpers';
+import { createErrorPayload } from '../utils/errorHelpers';
 import { Author, EmbedType, LocaleType } from '../interfaces';
 import { ImageEmbedType } from '../plugins/imagePlugin';
 
@@ -70,6 +72,10 @@ export const fetchImageResources = async (
   language: LocaleType,
 ): Promise<ImageEmbedType> => {
   const url = typeof embed.data.url === 'string' ? embed.data.url : '';
+  const lastElement = url.split('/').pop();
+  if (!isNumber(lastElement)) {
+    throw createErrorPayload(400, 'invalid image url');
+  }
   const response = await fetch(`${convertToInternalUrlIfPossible(url)}?language=${language}`, {
     headers: headerWithAccessToken(accessToken),
   });


### PR DESCRIPTION
Burde sikkert heller ikkje vist bilde.

Noen forklaringer har visuelt element som med en feil har fått tom resourceId og derfor har fått en embed-url som blir /image-api/v2/images som peiker på søket og ikkje ett bilde. Dette fører til at reponsen i linje 79 er et søkeresultat. Ved å legge til en throw så plukkes dette opp av onError og det vises en placeholder.

test:
* Kjør lokalt og start ed med `start-with-local-converter`.
* Åpne artikkelen 31329 og klikk på forhåndsvisning. sida er ikkje blank på grunn av feil i converter. forklaring lrv vises med placeholder for bildet.