### PR TITLE
Filters out h2-anchors also in textboxes.

### DIFF
--- a/src/__tests__/__snapshots__/htmlTransformers-test.js.snap
+++ b/src/__tests__/__snapshots__/htmlTransformers-test.js.snap
@@ -1,5 +1,146 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`addHeaderCopyLinkButtons only transforms h2 on root level 1`] = `
+"<section>
+  <figure>
+    <h2>Lorem ipsum dolor sit amet...</h2>
+  </figure>
+  <aside>
+    <h2>Test1</h2>
+    <div>Stuff</div>
+  </aside>
+  <style data-emotion-css=\\"8s0se0-ContainerDiv\\">
+    .css-8s0se0-ContainerDiv {
+      position: relative;
+    }
+    .css-8s0se0-ContainerDiv:hover button {
+      cursor: pointer;
+      opacity: 0.5;
+    }
+  </style>
+  <div
+    data-header-copy-container=\\"true\\"
+    data-title=\\"sdfjljklsdfjlsdf\\"
+    class=\\"css-8s0se0-ContainerDiv e18czas71\\"
+  >
+    <style data-emotion-css=\\"kgto6a-IconButton\\">
+      .css-kgto6a-IconButton {
+        position: absolute;
+        left: -3em;
+        top: 0.1em;
+        background: none;
+        border: 0;
+        z-index: 1;
+        -webkit-transition: 0.2s;
+        transition: 0.2s;
+        opacity: 0;
+      }
+      .css-kgto6a-IconButton svg {
+        width: 30px;
+        height: 30px;
+      }</style
+    ><button
+      data-title=\\"sdfjljklsdfjlsdf\\"
+      class=\\"css-kgto6a-IconButton e18czas70\\"
+    >
+      <style data-emotion-css=\\"1twu449-TooltipWrapper\\">
+        .css-1twu449-TooltipWrapper {
+          position: relative;
+        }
+      </style>
+      <div class=\\"css-1twu449-TooltipWrapper e13n7z1f0\\">
+        <style data-emotion-css=\\"1gms6h4-Fade\\">
+          .css-1gms6h4-Fade {
+            opacity: 0;
+            position: absolute;
+            z-index: 9999;
+            pointer-events: none;
+            -webkit-animation-fill-mode: forwards;
+            animation-fill-mode: forwards;
+            -webkit-animation-delay: 0ms;
+            animation-delay: 0ms;
+            -webkit-animation-duration: 300ms;
+            animation-duration: 300ms;
+          }
+          @-webkit-keyframes fadeInTooltip {
+            0% {
+              opacity: 0;
+            }
+            100% {
+              opacity: 1;
+            }
+          }
+          @keyframes fadeInTooltip {
+            0% {
+              opacity: 0;
+            }
+            100% {
+              opacity: 1;
+            }
+          }
+          @-webkit-keyframes fadeOutTooltip {
+            0% {
+              opacity: 1;
+            }
+            100% {
+              opacity: 0;
+            }
+          }
+          @keyframes fadeOutTooltip {
+            0% {
+              opacity: 1;
+            }
+            100% {
+              opacity: 0;
+            }
+          }
+        </style>
+        <div class=\\"css-1gms6h4-Fade e13n7z1f1\\">
+          <style data-emotion-css=\\"aztq0g-tooltipCss\\">
+            .css-aztq0g-tooltipCss{display:block;color:#fff;background:#444;border-radius:2px;padding:6.5px 13px;font-family:'Source Sans Pro',Helvetica,Arial,STKaiti,'华文楷体',KaiTi,SimKai,'楷体',KaiU,DFKai-SB,'標楷體',SongTi,'宋体',sans-serif;font-size:14;font-size:0.7777777777777778rem;line-height:1.2 font-weight:400;text-align:center;white-space:nowrap;max-width:calc(100vw - #{26px});}</style
+          ><span role=\\"tooltip\\" class=\\"css-aztq0g-tooltipCss\\"
+            >Kopier lenke til overskriften</span
+          >
+        </div>
+        <div aria-label=\\"Kopier lenke til overskriften\\" class=\\"\\">
+          <svg
+            fill=\\"currentColor\\"
+            preserveAspectRatio=\\"xMidYMid meet\\"
+            height=\\"1em\\"
+            width=\\"1em\\"
+            class=\\"c-icon\\"
+            viewBox=\\"0 0 24 24\\"
+            data-license=\\"Apache License 2.0\\"
+            data-source=\\"Material Design\\"
+            style=\\"vertical-align: middle\\"
+          >
+            <g>
+              <path d=\\"M0 0h24v24H0z\\" fill=\\"none\\"></path>
+              <path
+                d=\\"M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z\\"
+              ></path>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </button>
+    <h2 id=\\"sdfjljklsdfjlsdf\\" tabindex=\\"0\\">sdfjljklsdfjlsdf</h2>
+  </div>
+  <details>
+    <summary>Lorem ipsum dolor sit amet...</summary>
+    <div data-react-universal-portal=\\"true\\">
+      <h2>Modal dialog</h2>
+      <div>Stuff</div>
+    </div>
+  </details>
+  <div class=\\"c-bodybox\\">
+    <h2>sdfjljklsdfjlsdf</h2>
+  </div>
+  <p>sdfjljklsdfjlsdf</p>
+</section>
+"
+`;
+
 exports[`htmlTransforms adds display block to math tags 1`] = `
 "<html><head></head><body><section>
     <math xmlns=\\"http://www.w3.org/1998/Math/MathML\\" display=\\"block\\">

--- a/src/__tests__/__snapshots__/htmlTransformers-test.js.snap
+++ b/src/__tests__/__snapshots__/htmlTransformers-test.js.snap
@@ -3,10 +3,10 @@
 exports[`addHeaderCopyLinkButtons only transforms h2 on root level 1`] = `
 "<section>
   <figure>
-    <h2>Lorem ipsum dolor sit amet...</h2>
+    <h2>this header is not changed since placed in figure</h2>
   </figure>
   <aside>
-    <h2>Test1</h2>
+    <h2>neither does this in an aside</h2>
     <div>Stuff</div>
   </aside>
   <style data-emotion-css=\\"8s0se0-ContainerDiv\\">
@@ -20,7 +20,7 @@ exports[`addHeaderCopyLinkButtons only transforms h2 on root level 1`] = `
   </style>
   <div
     data-header-copy-container=\\"true\\"
-    data-title=\\"sdfjljklsdfjlsdf\\"
+    data-title=\\"this one is changed to copylinkbutton\\"
     class=\\"css-8s0se0-ContainerDiv e18czas71\\"
   >
     <style data-emotion-css=\\"kgto6a-IconButton\\">
@@ -40,7 +40,7 @@ exports[`addHeaderCopyLinkButtons only transforms h2 on root level 1`] = `
         height: 30px;
       }</style
     ><button
-      data-title=\\"sdfjljklsdfjlsdf\\"
+      data-title=\\"this-one-is-changed-to-copylinkbutton\\"
       class=\\"css-kgto6a-IconButton e18czas70\\"
     >
       <style data-emotion-css=\\"1twu449-TooltipWrapper\\">
@@ -124,17 +124,19 @@ exports[`addHeaderCopyLinkButtons only transforms h2 on root level 1`] = `
         </div>
       </div>
     </button>
-    <h2 id=\\"sdfjljklsdfjlsdf\\" tabindex=\\"0\\">sdfjljklsdfjlsdf</h2>
+    <h2 id=\\"this-one-is-changed-to-copylinkbutton\\" tabindex=\\"0\\">
+      this one is changed to copylinkbutton
+    </h2>
   </div>
   <details>
     <summary>Lorem ipsum dolor sit amet...</summary>
     <div data-react-universal-portal=\\"true\\">
-      <h2>Modal dialog</h2>
+      <h2>this is in a details so no change here</h2>
       <div>Stuff</div>
     </div>
   </details>
   <div class=\\"c-bodybox\\">
-    <h2>sdfjljklsdfjlsdf</h2>
+    <h2>header in bodybox is not changed either</h2>
   </div>
   <p>sdfjljklsdfjlsdf</p>
 </section>

--- a/src/__tests__/htmlTransformers-test.js
+++ b/src/__tests__/htmlTransformers-test.js
@@ -231,16 +231,16 @@ test('addHeaderCopyLinkButtons only transforms h2 on root level', () => {
   const content = cheerio.load(`
   <section>
     <figure>
-      <h2>Lorem ipsum dolor sit amet...</h2>
+      <h2>this header is not changed since placed in figure</h2>
     </figure>
-    <aside><h2>Test1</h2><div>Stuff</div></aside>
-    <h2>sdfjljklsdfjlsdf</h2>
+    <aside><h2>neither does this in an aside</h2><div>Stuff</div></aside>
+    <h2>this one is changed to copylinkbutton</h2>
     <details>
       <summary>Lorem ipsum dolor sit amet...</summary>
-      <div data-react-universal-portal="true"><h2>Modal dialog</h2><div>Stuff</div></div>
+      <div data-react-universal-portal="true"><h2>this is in a details so no change here</h2><div>Stuff</div></div>
     </details>
     <div class="c-bodybox">
-      <h2>sdfjljklsdfjlsdf</h2>
+      <h2>header in bodybox is not changed either</h2>
     </div>
     <p>sdfjljklsdfjlsdf</p>
   </section>`);

--- a/src/__tests__/htmlTransformers-test.js
+++ b/src/__tests__/htmlTransformers-test.js
@@ -14,6 +14,7 @@ import {
   transformAsides,
   transformTables,
   transformLinksInOembed,
+  addHeaderCopyLinkButtons,
 } from '../htmlTransformers';
 
 test('htmlTransforms changes ol to accommodate frontend styling', () => {
@@ -223,5 +224,29 @@ test('transformLinksInOembed adds target blank to a if oembed', () => {
 
   const result = content.html();
 
+  expect(prettify(result)).toMatchSnapshot();
+});
+
+test('addHeaderCopyLinkButtons only transforms h2 on root level', () => {
+  const content = cheerio.load(`
+  <section>
+    <figure>
+      <h2>Lorem ipsum dolor sit amet...</h2>
+    </figure>
+    <aside><h2>Test1</h2><div>Stuff</div></aside>
+    <h2>sdfjljklsdfjlsdf</h2>
+    <details>
+      <summary>Lorem ipsum dolor sit amet...</summary>
+      <div data-react-universal-portal="true"><h2>Modal dialog</h2><div>Stuff</div></div>
+    </details>
+    <div class="c-bodybox">
+      <h2>sdfjljklsdfjlsdf</h2>
+    </div>
+    <p>sdfjljklsdfjlsdf</p>
+  </section>`);
+
+  addHeaderCopyLinkButtons(content);
+
+  const result = content('body').html();
   expect(prettify(result)).toMatchSnapshot();
 });

--- a/src/htmlTransformers.ts
+++ b/src/htmlTransformers.ts
@@ -142,16 +142,7 @@ export const transformLinksInOembed = (
 export const addHeaderCopyLinkButtons = (content: CheerioAPI) => {
   content('h2')
     .filter((i, el) => {
-      return cheerio(el).parents('figure').length === 0;
-    })
-    .filter((i, el) => {
-      return cheerio(el).parents('details').length === 0;
-    })
-    .filter((i, el) => {
-      return cheerio(el).parents('aside').length === 0;
-    })
-    .filter((i, el) => {
-      return cheerio(el).parents('div[class=c-bodybox]').length === 0;
+      return cheerio(el).parents('figure, details, aside, div[class=c-bodybox]').length === 0;
     })
     .each((idx, h2) => {
       const headerElement = cheerio(h2);

--- a/src/htmlTransformers.ts
+++ b/src/htmlTransformers.ts
@@ -144,6 +144,15 @@ export const addHeaderCopyLinkButtons = (content: CheerioAPI) => {
     .filter((i, el) => {
       return cheerio(el).parents('figure').length === 0;
     })
+    .filter((i, el) => {
+      return cheerio(el).parents('details').length === 0;
+    })
+    .filter((i, el) => {
+      return cheerio(el).parents('aside').length === 0;
+    })
+    .filter((i, el) => {
+      return cheerio(el).parents('div[class=c-bodybox]').length === 0;
+    })
     .each((idx, h2) => {
       const headerElement = cheerio(h2);
       const innerHTML = headerElement.html();


### PR DESCRIPTION
Fixes NDLANO/Issues#2971

Sjekker at ikkje h2 konverteres inni details, aside eller bodybox. Kunne sikkert vore gjort meir elegant, men det fungerer.

Test
* Kjør lokalt med ed og sjekk at du ikkje får ankerknapp i denne artikkelen: http://localhost:3000/preview/31368/nb