### PR TITLE
Hotfix: Feilrettinger på apa-referanser

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@ndla/article-scripts": "^2.0.7",
     "@ndla/button": "^1.1.9",
     "@ndla/code": "^1.0.24",
-    "@ndla/licenses": "^2.1.0",
+    "@ndla/licenses": "^3.0.0",
     "@ndla/notion": "^1.1.17",
     "@ndla/safelink": "^1.0.13",
     "@ndla/ui": "^4.1.0",

--- a/src/__tests__/__snapshots__/getEmbedMetaData-test.js.snap
+++ b/src/__tests__/__snapshots__/getEmbedMetaData-test.js.snap
@@ -85,7 +85,7 @@ Object {
   "images": Array [
     Object {
       "altText": "alt",
-      "copyText": "title, av Etternavn, L. & Navnesen, N. NDLA. (http://example.no/1234.jpg). CC-BY-SA-4.0.",
+      "copyText": "title, av Etternavn, L., Navnesen, N. (http://example.no/1234.jpg). CC BY-SA 4.0.",
       "copyright": Object {
         "creators": Array [
           Object {
@@ -106,7 +106,7 @@ Object {
     },
     Object {
       "altText": "alt 2",
-      "copyText": "title 2, av Etternavn, L. & Navnesen, N. NDLA. (http://example.no/4123.jpg). CC-BY-SA-4.0.",
+      "copyText": "title 2, av Etternavn, L., Navnesen, N. (http://example.no/4123.jpg). CC BY-SA 4.0.",
       "copyright": Object {
         "creators": Array [
           Object {

--- a/src/__tests__/__snapshots__/replacer-test.js.snap
+++ b/src/__tests__/__snapshots__/replacer-test.js.snap
@@ -3870,7 +3870,7 @@ exports[`replacer/replaceEmbedsInHtml replace image embeds 1`] = `
                           ><button
                             type=\\"button\\"
                             data-copied-title=\\"Kopiert!\\"
-                            data-copy-string=\\"image title 1, av Foton, O. &amp; Maler, K. NDLA. (http://ndla.no/images/1.jpg). CC-BY-NC-4.0.\\"
+                            data-copy-string=\\"image title 1, av Foton, O., Maler, K., Scanpix. (http://ndla.no/images/1.jpg). CC BY-NC 4.0.\\"
                             class=\\"
                               css-1d2pibo-StyledButton-buttonStyle-outlineStyle-outline-outlineStyle-ButtonStyles
                               e1ww3yc20
@@ -4654,7 +4654,7 @@ exports[`replacer/replaceEmbedsInHtml replace image embeds 1`] = `
                           ><button
                             type=\\"button\\"
                             data-copied-title=\\"Kopiert!\\"
-                            data-copy-string=\\"image title 2, NDLA. (http://ndla.no/images/2.jpg). CC-BY-NC-4.0.\\"
+                            data-copy-string=\\"image title 2, (http://ndla.no/images/2.jpg). CC BY-NC 4.0.\\"
                             class=\\"
                               css-1d2pibo-StyledButton-buttonStyle-outlineStyle-outline-outlineStyle-ButtonStyles
                               e1ww3yc20
@@ -5501,7 +5501,7 @@ exports[`replacer/replaceEmbedsInHtml replace various emdeds in html 1`] = `
                           ><button
                             type=\\"button\\"
                             data-copied-title=\\"Kopiert!\\"
-                            data-copy-string=\\"image title, NDLA. (http://api.test.ndla.no/images/1.jpg). CC-BY-NC-4.0.\\"
+                            data-copy-string=\\"image title, (http://api.test.ndla.no/images/1.jpg). CC BY-NC 4.0.\\"
                             class=\\"
                               css-1d2pibo-StyledButton-buttonStyle-outlineStyle-outline-outlineStyle-ButtonStyles
                               e1ww3yc20

--- a/src/__tests__/integration-tests/article1036/__snapshots__/article1036-test.js.snap
+++ b/src/__tests__/integration-tests/article1036/__snapshots__/article1036-test.js.snap
@@ -22,7 +22,7 @@ Object {
   "id": 1036,
   "introduction": "FNs utviklingsprogram (UNDP) har flere ganger rangert Norge som det beste landet å leve i. Her skal vi ta for oss noen av de faktorene som gjør at Norge kommer såpass høyt opp på listene, og vi skal se litt på hva som ligger bak tallene.",
   "metaData": Object {
-    "copyText": "(2017, 7. juli). Levekår i dagens Norge. NDLA. https://test.ndla.no",
+    "copyText": "(2017, 7. juli). Levekår i dagens Norge. NDLA. https://test.ndla.no/article/1036",
     "footnotes": Array [
       Object {
         "authors": Array [
@@ -76,7 +76,7 @@ Object {
     "images": Array [
       Object {
         "altText": "",
-        "copyText": "Fottur på Kvamsfjellet, av Storfjell, I. NDLA. (https://test.api.ndla.no/image-api/raw/sxd08dab.jpg). CC-BY-NC-SA-4.0.",
+        "copyText": "Fottur på Kvamsfjellet, av Storfjell, I., Aftenposten, NTB scanpix. (https://test.api.ndla.no/image-api/raw/sxd08dab.jpg). CC BY-NC-SA 4.0.",
         "copyright": Object {
           "creators": Array [
             Object {
@@ -1552,7 +1552,7 @@ exports[`app/fetchAndTransformArticle 1036 2`] = `
             ><button
               type=\\"button\\"
               data-copied-title=\\"Kopiert!\\"
-              data-copy-string=\\"Fottur på Kvamsfjellet, av Storfjell, I. NDLA. (https://test.api.ndla.no/image-api/raw/sxd08dab.jpg). CC-BY-NC-SA-4.0.\\"
+              data-copy-string=\\"Fottur på Kvamsfjellet, av Storfjell, I., Aftenposten, NTB scanpix. (https://test.api.ndla.no/image-api/raw/sxd08dab.jpg). CC BY-NC-SA 4.0.\\"
               class=\\"
                 css-1d2pibo-StyledButton-buttonStyle-outlineStyle-outline-outlineStyle-ButtonStyles
                 e1ww3yc20

--- a/src/__tests__/integration-tests/article116/__snapshots__/article116-test.js.snap
+++ b/src/__tests__/integration-tests/article116/__snapshots__/article116-test.js.snap
@@ -62,7 +62,7 @@ Object {
         "uploadDate": "2017-04-07T01:14:55.016Z",
       },
     ],
-    "copyText": "(2017, 25. august). Offentlige debatter. NDLA. https://test.ndla.no",
+    "copyText": "(2017, 25. august). Offentlige debatter. NDLA. https://test.ndla.no/article/116",
   },
   "metaDescription": "",
   "oldNdlaUrl": "//red.ndla.no/node/125442",

--- a/src/__tests__/integration-tests/article13349/__snapshots__/article13349-test.js.snap
+++ b/src/__tests__/integration-tests/article13349/__snapshots__/article13349-test.js.snap
@@ -24,7 +24,7 @@ Object {
   "id": 13349,
   "introduction": "Her skal du installere og lære om forskjellige lyskilder styrt av de mest vanlige lysbryterne som blir brukt i boliger. Du skal lære deg åpen og skjult installasjon. Samtidig skal du lære om standarder og forskrifter som finnes i boliginstallasjon",
   "metaData": Object {
-    "copyText": "Olsen, S. (2018, 20. februar). Planlegging. NDLA. https://test.ndla.no",
+    "copyText": "Olsen, S. (2018, 20. februar). Planlegging. NDLA. https://test.ndla.no/article/13349",
   },
   "metaDescription": "Her skal du installere og lære om forskjellige lyskilder styrt av de mest vanlige lysbryterne som blir brukt i boliger.",
   "metaImage": Object {

--- a/src/__tests__/integration-tests/article2139/__snapshots__/article2139-test.js.snap
+++ b/src/__tests__/integration-tests/article2139/__snapshots__/article2139-test.js.snap
@@ -24,11 +24,11 @@ Object {
   "id": 2139,
   "introduction": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
   "metaData": Object {
-    "copyText": "Øyvind. (2017, 15. november). H₂O 💦. NDLA. https://test.ndla.no",
+    "copyText": "Øyvind. (2017, 15. november). H₂O 💦. NDLA. https://test.ndla.no/article/2139",
     "images": Array [
       Object {
         "altText": "",
-        "copyText": "Fottur på Kvamsfjellet, av Storfjell, I. NDLA. (https://test.api.ndla.no/image-api/raw/sxd08dab.jpg). CC-BY-NC-SA-4.0.",
+        "copyText": "Fottur på Kvamsfjellet, av Storfjell, I., Aftenposten, NTB scanpix. (https://test.api.ndla.no/image-api/raw/sxd08dab.jpg). CC BY-NC-SA 4.0.",
         "copyright": Object {
           "creators": Array [
             Object {
@@ -68,7 +68,7 @@ Object {
       },
       Object {
         "altText": "Rognkjeks som beveger seg i nettannonse. Animasjon.",
-        "copyText": "Annonse i gif-format, av Orangeriet, O. NDLA. (https://staging.api.ndla.no/image-api/raw/akvariet_rognkjeks.gif). CC-BY-SA-4.0.",
+        "copyText": "Annonse i gif-format, av Orangeriet, O. (https://staging.api.ndla.no/image-api/raw/akvariet_rognkjeks.gif). CC BY-SA 4.0.",
         "copyright": Object {
           "authors": Array [
             Object {
@@ -1251,7 +1251,7 @@ exports[`app/fetchAndTransformArticle 2139 2`] = `
             ><button
               type=\\"button\\"
               data-copied-title=\\"Kopiert!\\"
-              data-copy-string=\\"Fottur på Kvamsfjellet, av Storfjell, I. NDLA. (https://test.api.ndla.no/image-api/raw/sxd08dab.jpg). CC-BY-NC-SA-4.0.\\"
+              data-copy-string=\\"Fottur på Kvamsfjellet, av Storfjell, I., Aftenposten, NTB scanpix. (https://test.api.ndla.no/image-api/raw/sxd08dab.jpg). CC BY-NC-SA 4.0.\\"
               class=\\"
                 css-1d2pibo-StyledButton-buttonStyle-outlineStyle-outline-outlineStyle-ButtonStyles
                 e1ww3yc20
@@ -1621,7 +1621,7 @@ exports[`app/fetchAndTransformArticle 2139 2`] = `
             ><button
               type=\\"button\\"
               data-copied-title=\\"Kopiert!\\"
-              data-copy-string=\\"Annonse i gif-format, av Orangeriet, O. NDLA. (https://staging.api.ndla.no/image-api/raw/akvariet_rognkjeks.gif). CC-BY-SA-4.0.\\"
+              data-copy-string=\\"Annonse i gif-format, av Orangeriet, O. (https://staging.api.ndla.no/image-api/raw/akvariet_rognkjeks.gif). CC BY-SA 4.0.\\"
               class=\\"
                 css-1d2pibo-StyledButton-buttonStyle-outlineStyle-outline-outlineStyle-ButtonStyles
                 e1ww3yc20

--- a/src/__tests__/integration-tests/article270/__snapshots__/article270-test.js.snap
+++ b/src/__tests__/integration-tests/article270/__snapshots__/article270-test.js.snap
@@ -30,7 +30,7 @@ Object {
   "id": 270,
   "introduction": "Algebra brukes til å tolke og bruke formler som gjelder dagligliv og yrkesliv, vi bruker algebra til å til å forenkle uttrykk, regne med forhold, prosent, prosentpoeng og vekstfaktor, og når vi skal behandle proporsjonale og omvendt proporsjonale størrelser i praktiske sammenhenger.",
   "metaData": Object {
-    "copyText": "(2017, 15. september). Tall og algebra. NDLA. https://test.ndla.no",
+    "copyText": "(2017, 15. september). Tall og algebra. NDLA. https://test.ndla.no/article/270",
   },
   "metaDescription": "Tall er grunnlaget for all matematikk. Det er derfor veldig viktig å ha god tallforståelse for å gjøre det bra i matematikk.",
   "oldNdlaUrl": "//red.ndla.no/node/165193",
@@ -135,7 +135,7 @@ Object {
   "id": 270,
   "introduction": "Algebra brukes til å tolke og bruke formler som gjelder dagligliv og yrkesliv, vi bruker algebra til å til å forenkle uttrykk, regne med forhold, prosent, prosentpoeng og vekstfaktor, og når vi skal behandle proporsjonale og omvendt proporsjonale størrelser i praktiske sammenhenger.",
   "metaData": Object {
-    "copyText": "(2017, 15. september). Tall og algebra. NDLA. https://test.ndla.no",
+    "copyText": "(2017, 15. september). Tall og algebra. NDLA. https://test.ndla.no/article/270",
   },
   "metaDescription": "Tall er grunnlaget for all matematikk. Det er derfor veldig viktig å ha god tallforståelse for å gjøre det bra i matematikk.",
   "oldNdlaUrl": "//red.ndla.no/node/165193",

--- a/src/__tests__/integration-tests/article417/__snapshots__/article9206-test.js.snap
+++ b/src/__tests__/integration-tests/article417/__snapshots__/article9206-test.js.snap
@@ -24,7 +24,7 @@ Object {
   "id": 9206,
   "introduction": "Vi bruker skript for å tilføre funksjonalitet og interaktivitet på nettsider utover det vi kan lage med markeringsspråk og stilark. Det kan være alt fra små justeringer i design til hele spillkonsept.",
   "metaData": Object {
-    "copyText": "Nag, J. L. (2017, 7. mars). Skripting gjør sidene mer interaktive. NDLA. https://test.ndla.no",
+    "copyText": "Nag, J. L. (2017, 7. mars). Skripting gjør sidene mer interaktive. NDLA. https://test.ndla.no/article/9206",
   },
   "metaDescription": "Vi bruker skript for å tilføre funksjonalitet og interaktivitet på nettsider utover det vi kan lage med markeringsspråk og stilark. Det kan være alt fra små justeringer i design til hele spillkonsept.",
   "oldNdlaUrl": "//red.ndla.no/node/160589",

--- a/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
+++ b/src/__tests__/integration-tests/article4835/__snapshots__/article4835-test.js.snap
@@ -24,7 +24,7 @@ Object {
   "id": 4835,
   "introduction": "Forslag til årsplan for faget Matematikk Vg1P. Ligg vedlagt i ulike filformat slik at du kan endre og redigere.",
   "metaData": Object {
-    "copyText": "Larsen, G. (2018, 7. juni). Forslag til årsplan. NDLA. https://test.ndla.no",
+    "copyText": "Larsen, G. (2018, 7. juni). Forslag til årsplan. NDLA. https://test.ndla.no/article/4835",
   },
   "metaDescription": "Forslag til årsplan for faget Matematikk Vg1P. Ligg vedlagt i ulike filformat slik at du kan endre og redigere.",
   "metaImage": Object {

--- a/src/fetchAndTransformArticle.ts
+++ b/src/fetchAndTransformArticle.ts
@@ -39,7 +39,7 @@ export async function transformArticle(
     article.title.title,
     undefined,
     article.updated,
-    `/articles/${article.id}`,
+    `/article/${article.id}`,
     article.copyright,
     lang,
     config.ndlaFrontendDomain,

--- a/src/fetchAndTransformArticle.ts
+++ b/src/fetchAndTransformArticle.ts
@@ -37,14 +37,16 @@ export async function transformArticle(
 
   const copyText: string = webpageReferenceApa7CopyString(
     article.title.title,
-    config.ndlaFrontendDomain,
+    undefined,
     article.updated,
-    options.path,
+    `/articles/${article.id}`,
     article.copyright,
-    config.ndlaFrontendDomain,
     lang,
+    config.ndlaFrontendDomain,
     (id: string) => t(lang, id),
   );
+
+  console.log(copyText);
   const hasContent = article.articleType === 'standard' || cheerio.load(htmlString).text() !== '';
 
   return {

--- a/src/fetchAndTransformArticle.ts
+++ b/src/fetchAndTransformArticle.ts
@@ -46,7 +46,6 @@ export async function transformArticle(
     (id: string) => t(lang, id),
   );
 
-  console.log(copyText);
   const hasContent = article.articleType === 'standard' || cheerio.load(htmlString).text() !== '';
 
   return {

--- a/src/plugins/audioPlugin.tsx
+++ b/src/plugins/audioPlugin.tsx
@@ -84,6 +84,7 @@ export default function createAudioPlugin(options: TransformOptions = {}): Audio
               copyright.license.license,
               config.ndlaFrontendDomain,
               (id: string) => t(locale, id),
+              locale,
             )
           : undefined;
       return {
@@ -193,6 +194,7 @@ export default function createAudioPlugin(options: TransformOptions = {}): Audio
       copyright.license.license,
       config.ndlaFrontendDomain,
       (id: string) => t(locale, id),
+      locale,
     );
     const license = getLicenseByAbbreviation(licenseAbbreviation, locale);
     const authors = getLicenseCredits(copyright);
@@ -289,6 +291,7 @@ export default function createAudioPlugin(options: TransformOptions = {}): Audio
             audio.copyright.license.license,
             config.ndlaFrontendDomain,
             (id: string) => t(locale, id),
+            locale,
           )
         : undefined;
     const captionAuthors = getFirstNonEmptyLicenseCredits(authors);

--- a/src/plugins/imagePlugin.tsx
+++ b/src/plugins/imagePlugin.tsx
@@ -228,6 +228,7 @@ export default function createImagePlugin(
         copyright.license.license,
         config.ndlaFrontendDomain,
         (id: string) => t(locale, id),
+        locale,
       );
       return {
         title: title,
@@ -307,6 +308,7 @@ export default function createImagePlugin(
       copyright.license.license,
       config.ndlaFrontendDomain,
       (id: string) => t(locale, id),
+      locale,
     );
     const unique = uniqueId();
     const figureId = `figure-${unique}-${id}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,6 +1797,15 @@
     polished "^4.1.3"
     sass-mq "^5.0.1"
 
+"@ndla/core@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ndla/core/-/core-1.0.0.tgz#e210ae2ddf7ec2b898b0c378d364e2b9ae790e3d"
+  integrity sha512-X6x/ZAYXluWrKAVh+ZOHvs1bDBIBqO98l4LE4siqokSY3Y1kS1+gV0WZ/KmYGiqMCg+LHKLGEGaVUTyXYf1RDg==
+  dependencies:
+    inuitcss "6.0.0"
+    polished "^4.1.3"
+    sass-mq "^5.0.1"
+
 "@ndla/hooks@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@ndla/hooks/-/hooks-1.0.8.tgz#361631aca9f818eac8b9e53e09ba84a5c635d836"
@@ -1810,6 +1819,11 @@
   resolved "https://registry.yarnpkg.com/@ndla/icons/-/icons-1.5.0.tgz#706cf478dd071b02f139b471e3dcfd5c58c826b7"
   integrity sha512-60fybq2yA3I5GBhBv8j2PjZ2LrJFqwQuJSjzk8IZ/xrmpDgRSn2OK4ZOHCiSMh7uDNo6dEZzNMQb9Zv5W3or9Q==
 
+"@ndla/icons@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@ndla/icons/-/icons-1.6.0.tgz#0711535f7361e5476dba2afb1211821a22c14bed"
+  integrity sha512-eYeBhaGvbLTylUsiXEKKmPFQ+VKzLus32yrXwWE6bq6zDhbmTvu/mDDkOYEE2lg7Lro7EdstBLqkE/MW+mneeg==
+
 "@ndla/licenses@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@ndla/licenses/-/licenses-2.1.0.tgz#5a4cfb42d715f8eac66210158c2b5c507674e666"
@@ -1818,6 +1832,14 @@
     "@ndla/core" "^0.7.3"
     "@ndla/icons" "^1.5.0"
     react-bem-helper "1.4.1"
+
+"@ndla/licenses@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@ndla/licenses/-/licenses-3.0.0.tgz#8156fcfc73328a142ebd3dc6399894a12d9043a8"
+  integrity sha512-eOdo6i62oNxbBnFzlNDJu26jtIF50sHcCE1Z7qPxawPHR2Y0eDv7HRl+dFDjL80sXcwXsRKWIZ+FD0zFMjENvQ==
+  dependencies:
+    "@ndla/core" "^1.0.0"
+    "@ndla/icons" "^1.6.0"
 
 "@ndla/modal@^1.1.25":
   version "1.1.25"


### PR DESCRIPTION
Testes lokalt med graphql og ndla-frontend.

Følgende er nytt i tekst for kopiering under "regler for bruk" og i figurer i artikkelen:
- Både opphavere og rettighetshavere listes opp dersom begge deler finnes.
- Personer/organisasjoner skilles med komma

Spesifikt for kildehenvisning til artikkel (se "regler for bruk" i bunnen av en artikkel):
- kort url til artikkel brukes. Altså /articles/:id og nå vises også ndla-domene (feks http://test.ndla.no) i starten av url.