### PR TITLE
Add alt-text to article if previewAlt is specified.

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -74,6 +74,7 @@ export interface TransformOptions {
   path?: string;
   shortPath?: string;
   previewH5p?: boolean;
+  previewAlt?: boolean;
   showVisualElement?: boolean;
   subject?: string;
   transform?: TransformFunction;

--- a/src/plugins/imagePlugin.tsx
+++ b/src/plugins/imagePlugin.tsx
@@ -370,8 +370,8 @@ export default function createImagePlugin(
                   src={imageUrl}
                   expandButton={<ExpandButton size={size} typeClass={typeClass} />}
                 />
-                {altTextSpan}
               </ImageWrapper>
+              {altTextSpan}
               <FigureCaption
                 hideFigcaption={isSmall(size) || hideByline(size)}
                 figureId={figureId}

--- a/src/plugins/imagePlugin.tsx
+++ b/src/plugins/imagePlugin.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { uniqueId } from 'lodash';
+import styled from '@emotion/styled';
 import {
   Figure,
   FigureLicenseDialog,
@@ -42,6 +43,11 @@ import {
 import config from '../config';
 
 const Anchor = StyledButton.withComponent('a');
+
+const StyledSpan = styled.span`
+  font-style: italic;
+  color: grey;
+`;
 
 const getFigureType = (size: string, align: string): FigureType => {
   if (isSmall(size) && isAlign(align)) {
@@ -345,6 +351,10 @@ export default function createImagePlugin(
     const captionAuthors =
       creators.length || rightsholders.length ? [...creators, ...rightsholders] : processors;
 
+    const altTextSpan = options.previewAlt ? (
+      <StyledSpan>{`Alt: ${altText}`}</StyledSpan>
+    ) : undefined;
+
     return {
       html: render(
         <Figure id={figureId} type={options.concept ? 'full-column' : figureType}>
@@ -360,6 +370,7 @@ export default function createImagePlugin(
                   src={imageUrl}
                   expandButton={<ExpandButton size={size} typeClass={typeClass} />}
                 />
+                {altTextSpan}
               </ImageWrapper>
               <FigureCaption
                 hideFigcaption={isSmall(size) || hideByline(size)}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -115,6 +115,7 @@ const setup = function routes(app: Express) {
     const lang = getHtmlLang(req.params.lang ?? '');
     const draftConcept = req.query.draftConcept === 'true';
     const previewH5p = req.query.previewH5p === 'true';
+    const previewAlt = req.query.previewAlt === 'true';
     const showVisualElement = req.query.showVisualElement === 'true';
     const absoluteUrl = req.query.absoluteUrl === 'true';
 
@@ -125,6 +126,7 @@ const setup = function routes(app: Express) {
         showVisualElement,
         draftConcept,
         previewH5p,
+        previewAlt,
         absoluteUrl,
       })
         .then((article) => {


### PR DESCRIPTION
Viser alt-tekst for bilder dersom article-converter kalles fra ed med en gitt parameter.

![image](https://user-images.githubusercontent.com/8956884/157411287-859d1451-2db3-4234-b46a-90df11bb896e.png)

Test:
* Kjøres sammen med tilhørende PR i ed
* Forhåndsvisning og språksammenligning skal ha med alt-tekst.