### PR TITLE
Hide copytext on copyright

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@ndla/article-scripts": "^2.0.7",
     "@ndla/button": "^1.1.9",
     "@ndla/code": "^1.0.24",
-    "@ndla/licenses": "^3.0.0",
+    "@ndla/licenses": "^3.0.1",
     "@ndla/notion": "^1.1.17",
     "@ndla/safelink": "^1.0.13",
     "@ndla/ui": "^4.1.0",

--- a/src/plugins/audioPlugin.tsx
+++ b/src/plugins/audioPlugin.tsx
@@ -139,6 +139,9 @@ export default function createAudioPlugin(options: TransformOptions = {}): Audio
     license: string;
     src: string;
   }) => {
+    if (license === 'COPYRIGHTED') {
+      return null;
+    }
     return (
       <>
         {copyString && (
@@ -150,11 +153,9 @@ export default function createAudioPlugin(options: TransformOptions = {}): Audio
             {t(locale, 'license.copyTitle')}
           </Button>
         )}
-        {license !== 'COPYRIGHTED' && (
-          <Anchor key="download" href={src} download appearance="outline">
-            {t(locale, 'audio.download')}
-          </Anchor>
-        )}
+        <Anchor key="download" href={src} download appearance="outline">
+          {t(locale, 'audio.download')}
+        </Anchor>
       </>
     );
   };

--- a/src/plugins/imagePlugin.tsx
+++ b/src/plugins/imagePlugin.tsx
@@ -168,6 +168,9 @@ export const ImageActionButtons = ({
   license,
   src,
 }: ImageActionButtonsProps) => {
+  if (license === 'COPYRIGHTED') {
+    return null;
+  }
   return (
     <>
       <Button
@@ -177,11 +180,9 @@ export const ImageActionButtons = ({
         data-copy-string={copyString}>
         {t(locale, 'license.copyTitle')}
       </Button>
-      {license !== 'COPYRIGHTED' && (
-        <Anchor key="download" href={downloadUrl(src)} appearance="outline" download>
-          {t(locale, 'image.download')}
-        </Anchor>
-      )}
+      <Anchor key="download" href={downloadUrl(src)} appearance="outline" download>
+        {t(locale, 'image.download')}
+      </Anchor>
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,10 +1833,10 @@
     "@ndla/icons" "^1.5.0"
     react-bem-helper "1.4.1"
 
-"@ndla/licenses@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@ndla/licenses/-/licenses-3.0.0.tgz#8156fcfc73328a142ebd3dc6399894a12d9043a8"
-  integrity sha512-eOdo6i62oNxbBnFzlNDJu26jtIF50sHcCE1Z7qPxawPHR2Y0eDv7HRl+dFDjL80sXcwXsRKWIZ+FD0zFMjENvQ==
+"@ndla/licenses@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@ndla/licenses/-/licenses-3.0.1.tgz#f264117cf928993575fad2271b416ec844605611"
+  integrity sha512-hUlm0N/OYzUdwo/WTLYs0zcd+QGNQMv/pJ6JCti9uM1gAU3K1KJHnPL6pAl4K+LBWRs8043ko+T6NMb9d2xe2A==
   dependencies:
     "@ndla/core" "^1.0.0"
     "@ndla/icons" "^1.6.0"


### PR DESCRIPTION
Dersom et bilde har copyright skal ikke knapp for kopiering av kildehenvisning vises. Denne PRen fikser dette for figurerer som vises underveis i en artikkel.

Hvordan teste:
1. Spinn opp ndla-frontend med lokal graphql og article-converter.
2. Åpne en artikkel som innholder et bilde med COPYRIGHT som lisens.
3. Trykk på regler for bruk og sjekk at bildet ikke har knapp for verken nedlasting eller kildehenvisning