### PR TITLE
Add custom attribute for converter rendered portals

### DIFF
--- a/src/__tests__/__snapshots__/htmlTransformers-test.js.snap
+++ b/src/__tests__/__snapshots__/htmlTransformers-test.js.snap
@@ -163,7 +163,7 @@ exports[`move react portals to bottom 1`] = `
       <p>Lorem ipsum dolor sit amet...</p>
       
     </figure>
-  </section><div data-react-universal-portal=\\"true\\"><h2>Modal dialog</h2><div>Stuff</div></div></body></html>"
+  </section><div data-react-universal-portal=\\"true\\" data-from-article-converter=\\"true\\"><h2>Modal dialog</h2><div>Stuff</div></div></body></html>"
 `;
 
 exports[`transformAsides duplicates right column aside for better narrowscreen experience 1`] = `

--- a/src/__tests__/integration-tests/article1036/__snapshots__/article1036-test.js.snap
+++ b/src/__tests__/integration-tests/article1036/__snapshots__/article1036-test.js.snap
@@ -1212,7 +1212,7 @@ exports[`app/fetchAndTransformArticle 1036 2`] = `
     <br />
   </p>
 </section>
-<div data-react-universal-portal=\\"true\\">
+<div data-react-universal-portal=\\"true\\" data-from-article-converter=\\"true\\">
   <div
     class=\\"c-dialog\\"
     data-dialog-id=\\"figure-1-2357\\"

--- a/src/__tests__/integration-tests/article116/__snapshots__/article116-test.js.snap
+++ b/src/__tests__/integration-tests/article116/__snapshots__/article116-test.js.snap
@@ -449,7 +449,7 @@ exports[`app/fetchAndTransformArticle 116 2`] = `
     </figcaption>
   </figure>
 </section>
-<div data-react-universal-portal=\\"true\\">
+<div data-react-universal-portal=\\"true\\" data-from-article-converter=\\"true\\">
   <div
     class=\\"c-dialog\\"
     data-dialog-id=\\"5388709430001\\"

--- a/src/__tests__/integration-tests/article2139/__snapshots__/article2139-test.js.snap
+++ b/src/__tests__/integration-tests/article2139/__snapshots__/article2139-test.js.snap
@@ -911,7 +911,7 @@ exports[`app/fetchAndTransformArticle 2139 2`] = `
   </figure>
   <p></p>
 </section>
-<div data-react-universal-portal=\\"true\\">
+<div data-react-universal-portal=\\"true\\" data-from-article-converter=\\"true\\">
   <div
     class=\\"c-dialog\\"
     data-dialog-id=\\"figure-1-2357\\"
@@ -1333,7 +1333,7 @@ exports[`app/fetchAndTransformArticle 2139 2`] = `
     <div class=\\"o-backdrop\\"></div>
   </div>
 </div>
-<div data-react-universal-portal=\\"true\\">
+<div data-react-universal-portal=\\"true\\" data-from-article-converter=\\"true\\">
   <div
     class=\\"c-dialog\\"
     data-dialog-id=\\"figure-2-347\\"

--- a/src/htmlTransformers.ts
+++ b/src/htmlTransformers.ts
@@ -21,6 +21,9 @@ import { checkIfFileExists } from './api/filesApi';
 import { LocaleType, TransformOptions } from './interfaces';
 
 export const moveReactPortals = (content: CheerioAPI) => {
+  content(`[data-react-universal-portal='true']`).each((_, el) => {
+    content(el).attr('data-from-article-converter', 'true');
+  });
   const dialog = cheerio.html(content(`[data-react-universal-portal='true']`));
   content(`[data-react-universal-portal='true']`).remove();
   content('body').append(dialog);


### PR DESCRIPTION
Relatert til https://github.com/NDLANO/ndla-frontend/pull/951
Legger til attributten `data-from-article-converter`, som lar oss unngå å utføre spesifikke handlinger på ting som kommer fra article-converter.