### PR TITLE
path is no longer null when missing, it is an empty string, fix check…

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -95,11 +95,11 @@ export async function fetchArticleResource(
 
   const topics = await queryTopics(contentId, accessToken, language, contentType);
 
-  const withPath = topics.filter((t) => t.path !== null);
+  const withPath = topics.find((t) => t.path);
 
-  if (withPath[0]) {
+  if (withPath) {
     // Add resourceType so that content type is correct
-    return { ...withPath[0], resourceTypes: [{ id: 'subject' }] };
+    return { ...withPath, resourceTypes: [{ id: 'subject' }] };
   }
 
   return undefined;


### PR DESCRIPTION
… for missing path

Fixes https://github.com/NDLANO/Issues/issues/3055

Testartikkel med ufungerende linking: https://test.ndla.no/article/31426
Første lenken peker feil sted, skal egentlig peke til taxonomy url siden dette er et emne

Spinn opp article-converter lokalt og sjekk at første lenken i samme artikkelen har taxonomy-url. 