### PR TITLE
Increase body size

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,11 +35,12 @@ const swaggerOptions = {
 const swaggerSpec = swaggerJSDoc(swaggerOptions);
 
 const app = express();
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: '2mb' }));
 app.use(
   bodyParser.urlencoded({
     // To support URL-encoded bodies
     extended: true,
+    limit: '2mb',
   }),
 );
 app.use(compression());


### PR DESCRIPTION
NDLANO/Issues#3070

Express defaulter til 100K som maks størrelse, men det er i noen tilfeller for lite. Øker denne til 2mb her og i api-gateway for å ha litt å gå på.

Kan testes med å forhåndsvise denne sida om du kjører ed med lokal converter: http://localhost:3000/nn/preview/31431/nb
Uten denne endringa vil du få tom side og 413 feil fra converter.