### PR TITLE
Moves moveReactPortals further down so that it runs after tables have been transformed

### DIFF
--- a/src/htmlTransformers.ts
+++ b/src/htmlTransformers.ts
@@ -176,7 +176,6 @@ export const htmlTransforms: ((
     content('ul[data-type="two-column"]').removeAttr('data-type').addClass('o-list--two-columns'),
   (content: CheerioAPI) =>
     content('p[data-align="center"]').removeAttr('data-align').addClass('u-text-center'),
-  moveReactPortals,
   (content: CheerioAPI) =>
     content('span[data-size="large"]').removeAttr('data-size').addClass('u-large-body-text'),
   (content: CheerioAPI) => content('h3').attr('tabindex', '0'),
@@ -185,5 +184,6 @@ export const htmlTransforms: ((
   transformTables,
   transformFileList,
   transformLinksInOembed,
+  moveReactPortals,
   transformAsides, // since transformAsides duplicates content all other transforms should be run first
 ];


### PR DESCRIPTION
Fikser problemet på http://localhost:3000/nn/subject:1:3b74fa5e-aeb8-4bc3-b771-fb2c0230b5f4/topic:1:ad12f9f6-2770-4fa6-a710-bbb7cd669651/topic:1:06ae6019-ae22-4964-ad65-ea8ef03d7ba1/resource:1:122989

Kan testes ved å starte opp lokal graphql, article-converter og ndla-frontend, for deretter å gå inn på linken over. Hvis det ikke krasjer funker det.