### PR TITLE
Add support for `correlationId`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.16'
+          node-version: '14.20'
       - name: "Login to ECR repo"
         run: RES=$(aws sts assume-role --role-arn $CI_RELEASE_ROLE --role-session-name github-actions-ecr-login)
           AWS_ACCESS_KEY_ID=$(echo $RES | jq -r .Credentials.AccessKeyId)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16-alpine
+FROM node:14.20-alpine
 
 ENV HOME=/home/app
 ENV APP_PATH=$HOME/article-converter

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14.20-alpine
 ENV HOME=/home/app
 ENV APP_PATH=$HOME/article-converter
 
-RUN apk add py2-pip jq && pip install awscli
+RUN apk add py-pip jq && pip install awscli
 COPY run-article-converter.sh /
 RUN npm install pm2 -g
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "snyk-protect": "snyk-protect"
   },
   "engines": {
-    "node": ">=14.16.0"
+    "node": ">=14.20.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/remarkable": "^2.0.3",
     "@types/swagger-jsdoc": "^6.0.1",
     "@types/swagger-ui-express": "^4.1.3",
+    "@types/node": "^14.18.28",
     "babel-jest": "^27.2.1",
     "chalk": "^4.1.2",
     "concurrently": "^5.3.0",

--- a/src/__tests__/integration-tests/article1036/article1036-test.js
+++ b/src/__tests__/integration-tests/article1036/article1036-test.js
@@ -7,13 +7,13 @@
  */
 
 import nock from 'nock';
-import { prettify } from '../../testHelpers';
+import { loglessTest, prettify } from '../../testHelpers';
 import article1036 from './article1036';
 import image2357 from './image2357';
 
 import fetchAndTransformArticle from '../../../fetchAndTransformArticle';
 
-test('app/fetchAndTransformArticle 1036', async () => {
+loglessTest('app/fetchAndTransformArticle 1036', async () => {
   nock('http://ndla-api')
     .get('/article-api/v2/articles/1036?language=nb&fallback=true')
     .reply(200, article1036);

--- a/src/__tests__/integration-tests/article116/article116-test.js
+++ b/src/__tests__/integration-tests/article116/article116-test.js
@@ -7,14 +7,14 @@
  */
 
 import nock from 'nock';
-import { prettify } from '../../testHelpers';
+import { loglessTest, prettify } from '../../testHelpers';
 import article116 from './article116';
 import video125442 from './video125442';
 import videoSources125442 from './videoSources125442';
 
 import fetchAndTransformArticle from '../../../fetchAndTransformArticle';
 
-test('app/fetchAndTransformArticle 116', async () => {
+loglessTest('app/fetchAndTransformArticle 116', async () => {
   nock('http://ndla-api')
     .get('/article-api/v2/articles/116?language=nb&fallback=true')
     .reply(200, article116);

--- a/src/__tests__/integration-tests/article13349/article13349-test.js
+++ b/src/__tests__/integration-tests/article13349/article13349-test.js
@@ -7,13 +7,13 @@
  */
 
 import nock from 'nock';
-import { prettify } from '../../testHelpers';
+import { loglessTest, prettify } from '../../testHelpers';
 import article13349 from './article13349';
 
 import fetchAndTransformArticle from '../../../fetchAndTransformArticle';
 
 // Tests that we can have a filelist inside aside
-test('app/fetchAndTransformArticle 13349', async () => {
+loglessTest('app/fetchAndTransformArticle 13349', async () => {
   nock('http://ndla-api')
     .get('/article-api/v2/articles/13349?language=nb&fallback=true')
     .reply(200, article13349);

--- a/src/__tests__/integration-tests/article2139/article2139-test.js
+++ b/src/__tests__/integration-tests/article2139/article2139-test.js
@@ -7,14 +7,14 @@
  */
 
 import nock from 'nock';
-import { prettify } from '../../testHelpers';
+import { loglessTest, prettify } from '../../testHelpers';
 import article2139 from './article2139';
 import image2357 from './image2357';
 import image347 from './image347';
 
 import fetchAndTransformArticle from '../../../fetchAndTransformArticle';
 
-test('app/fetchAndTransformArticle 2139', async () => {
+loglessTest('app/fetchAndTransformArticle 2139', async () => {
   nock('http://ndla-api')
     .get('/article-api/v2/articles/2139?language=nb&fallback=true')
     .reply(200, article2139);

--- a/src/__tests__/integration-tests/article270/article270-test.js
+++ b/src/__tests__/integration-tests/article270/article270-test.js
@@ -7,12 +7,12 @@
  */
 
 import nock from 'nock';
-import { prettify } from '../../testHelpers';
+import { loglessTest, prettify } from '../../testHelpers';
 import article270 from './article270';
 
 import fetchAndTransformArticle from '../../../fetchAndTransformArticle';
 
-test('app/fetchAndTransformArticle 270', async () => {
+loglessTest('app/fetchAndTransformArticle 270', async () => {
   nock('http://ndla-api')
     .get('/article-api/v2/articles/270?language=nb&fallback=true')
     .reply(200, article270);
@@ -30,7 +30,7 @@ test('app/fetchAndTransformArticle 270', async () => {
   expect(prettify(content)).toMatchSnapshot();
 });
 
-test('app/fetchAndTransformArticle 270 with visualElement', async () => {
+loglessTest('app/fetchAndTransformArticle 270 with visualElement', async () => {
   nock('http://ndla-api')
     .get('/article-api/v2/articles/270?language=nb&fallback=true')
     .reply(200, article270);

--- a/src/__tests__/integration-tests/article417/article9206-test.js
+++ b/src/__tests__/integration-tests/article417/article9206-test.js
@@ -13,7 +13,7 @@ import article9206 from './article9206';
 import articleResource1128 from './articleResource1128';
 import articleResource9202 from './articleResource9202';
 import fetchAndTransformArticle from '../../../fetchAndTransformArticle';
-import log from '../../../utils/logger';
+import getLogger from '../../../utils/logger';
 
 const resources = {
   1128: articleResource1128,
@@ -22,6 +22,7 @@ const resources = {
 };
 
 test('app/fetchAndTransformArticle 9206', async () => {
+  const log = getLogger();
   nock('http://ndla-api')
     .get('/article-api/v2/articles/9206?language=nb&fallback=true')
     .reply(200, article9206);

--- a/src/__tests__/integration-tests/article417/article9206-test.js
+++ b/src/__tests__/integration-tests/article417/article9206-test.js
@@ -8,7 +8,7 @@
 
 import nock from 'nock';
 import bunyan from 'bunyan';
-import { prettify } from '../../testHelpers';
+import { loglessTest, prettify } from '../../testHelpers';
 import article9206 from './article9206';
 import articleResource1128 from './articleResource1128';
 import articleResource9202 from './articleResource9202';
@@ -21,7 +21,7 @@ const resources = {
   1129: articleResource1128,
 };
 
-test('app/fetchAndTransformArticle 9206', async () => {
+loglessTest('app/fetchAndTransformArticle 9206', async () => {
   const log = getLogger();
   nock('http://ndla-api')
     .get('/article-api/v2/articles/9206?language=nb&fallback=true')

--- a/src/__tests__/integration-tests/article4835/article4835-test.js
+++ b/src/__tests__/integration-tests/article4835/article4835-test.js
@@ -7,12 +7,12 @@
  */
 
 import nock from 'nock';
-import { prettify } from '../../testHelpers';
+import { loglessTest, prettify } from '../../testHelpers';
 import article4835 from './article4835';
 
 import fetchAndTransformArticle from '../../../fetchAndTransformArticle';
 
-test('app/fetchAndTransformArticle 4835', async () => {
+loglessTest('app/fetchAndTransformArticle 4835', async () => {
   nock('http://ndla-api')
     .get('/article-api/v2/articles/4835?language=nb&fallback=true')
     .reply(200, article4835);

--- a/src/__tests__/testHelpers.ts
+++ b/src/__tests__/testHelpers.ts
@@ -7,6 +7,18 @@
  */
 
 import prettier from 'prettier';
+import bunyan from 'bunyan';
+import getLogger from '../utils/logger';
 
 // Use prettier to format html for better diffing. N.B. prettier html formating is currently experimental
 export const prettify = (content) => prettier.format(`${content}`, { parser: 'html' });
+
+export function withoutLog(callback) {
+  return async () => {
+    const log = getLogger();
+    log.level(bunyan.FATAL + 1);
+    const result = await callback();
+    log.level(bunyan.INFO);
+    return result;
+  };
+}

--- a/src/__tests__/testHelpers.ts
+++ b/src/__tests__/testHelpers.ts
@@ -11,9 +11,9 @@ import bunyan from 'bunyan';
 import getLogger from '../utils/logger';
 
 // Use prettier to format html for better diffing. N.B. prettier html formating is currently experimental
-export const prettify = (content) => prettier.format(`${content}`, { parser: 'html' });
+export const prettify = (content: any) => prettier.format(`${content}`, { parser: 'html' });
 
-export function withoutLog(callback) {
+export function withoutLog<T>(callback: () => Promise<T>): () => Promise<T> {
   return async () => {
     const log = getLogger();
     log.level(bunyan.FATAL + 1);
@@ -21,4 +21,9 @@ export function withoutLog(callback) {
     log.level(bunyan.INFO);
     return result;
   };
+}
+
+export function loglessTest<T>(name: string, callback: () => Promise<T>, timeout?: number): void {
+  const fn = withoutLog(callback);
+  return test(name, fn, timeout);
 }

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import fetch from 'isomorphic-fetch';
 import { IArticleV2 } from '@ndla/types-article-api';
 import {
   apiResourceUrl,
@@ -14,6 +13,7 @@ import {
   headerWithAccessToken,
 } from '../utils/apiHelpers';
 import { ApiOptions, ResponseHeaders } from '../interfaces';
+import { ndlaFetch } from './ndlaFetch';
 
 export async function fetchArticle(
   articleId: number | string,
@@ -21,7 +21,7 @@ export async function fetchArticle(
 ): Promise<{ article: IArticleV2; responseHeaders: ResponseHeaders }> {
   const feideHeader = apiOptions.feideToken ? { FeideAuthorization: apiOptions.feideToken } : null;
   const headers = { ...headerWithAccessToken(apiOptions.accessToken), ...feideHeader };
-  const response = await fetch(
+  const response = await ndlaFetch(
     apiResourceUrl(
       `/article-api/v2/articles/${articleId}?language=${apiOptions.lang}&fallback=true`,
     ),

--- a/src/api/audioApi.ts
+++ b/src/api/audioApi.ts
@@ -7,7 +7,6 @@
  */
 
 import { IAudioMetaInformation } from '@ndla/types-audio-api';
-import fetch from 'isomorphic-fetch';
 import { ApiOptions, PlainEmbed } from '../interfaces';
 import { AudioEmbed, AudioEmbedData } from '../plugins/audioPlugin';
 import {
@@ -15,13 +14,14 @@ import {
   headerWithAccessToken,
   resolveJsonOrRejectWithError,
 } from '../utils/apiHelpers';
+import { ndlaFetch } from './ndlaFetch';
 
 export const fetchAudio = (
   embed: PlainEmbed<AudioEmbedData>,
   apiOptions: ApiOptions,
 ): Promise<AudioEmbed> => {
   const url = typeof embed.data.url === 'string' ? embed.data.url : '';
-  return fetch(`${convertToInternalUrlIfPossible(url)}?language=${apiOptions.lang}`, {
+  return ndlaFetch(`${convertToInternalUrlIfPossible(url)}?language=${apiOptions.lang}`, {
     headers: headerWithAccessToken(apiOptions.accessToken),
   })
     .then((res) => resolveJsonOrRejectWithError<IAudioMetaInformation>(res))

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import fetch from 'isomorphic-fetch';
 import { IConcept, IConceptSearchResult } from '@ndla/types-concept-api';
 import {
   apiResourceUrl,
@@ -16,6 +15,7 @@ import {
 import { ApiOptions, PlainEmbed } from '../interfaces';
 import { ConceptEmbedData, ConceptEmbed } from '../plugins/conceptPlugin';
 import { ConceptListEmbed, ConceptListEmbedData } from '../plugins/conceptListPlugin';
+import { ndlaFetch } from './ndlaFetch';
 
 export const fetchConcept = async (
   embed: PlainEmbed<ConceptEmbedData>,
@@ -29,7 +29,7 @@ export const fetchConcept = async (
   const url = apiResourceUrl(
     `/concept-api/v1/${endpoint}/${embed.data.contentId}?language=${apiOptions.lang}&fallback=true`,
   );
-  const response = await fetch(url, {
+  const response = await ndlaFetch(url, {
     method,
     headers: headerWithAccessToken(apiOptions.accessToken),
   });
@@ -54,7 +54,7 @@ export const fetchConcepts = async (
       subjectId && `&subjects=${subjectId}`
     }`,
   );
-  const response = await fetch(url, {
+  const response = await ndlaFetch(url, {
     method,
     headers: headerWithAccessToken(apiOptions.accessToken),
   });

--- a/src/api/filesApi.ts
+++ b/src/api/filesApi.ts
@@ -6,10 +6,10 @@
  *
  */
 
-import fetch from 'isomorphic-fetch';
 import { convertToInternalUrlIfPossible } from '../utils/apiHelpers';
+import { ndlaFetch } from './ndlaFetch';
 
 export async function checkIfFileExists(fileUrl: string): Promise<boolean> {
-  const response = await fetch(convertToInternalUrlIfPossible(fileUrl), { method: 'HEAD' });
+  const response = await ndlaFetch(convertToInternalUrlIfPossible(fileUrl), { method: 'HEAD' });
   return response.status === 200;
 }

--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -7,19 +7,19 @@
  */
 
 import { IImageMetaInformationV2 } from '@ndla/types-image-api';
-import fetch from 'isomorphic-fetch';
 import { ApiOptions } from '../interfaces';
 import {
   convertToInternalUrlIfPossible,
   headerWithAccessToken,
   resolveJsonOrRejectWithError,
 } from '../utils/apiHelpers';
+import { ndlaFetch } from './ndlaFetch';
 
 export const fetchImageResources = async (
   url: string,
   apiOptions: ApiOptions,
 ): Promise<IImageMetaInformationV2> => {
-  const response = await fetch(
+  const response = await ndlaFetch(
     `${convertToInternalUrlIfPossible(url)}?language=${apiOptions.lang}`,
     {
       headers: headerWithAccessToken(apiOptions.accessToken),

--- a/src/api/ndlaFetch.ts
+++ b/src/api/ndlaFetch.ts
@@ -1,0 +1,19 @@
+import fetch from 'isomorphic-fetch';
+import { getCorrelationId } from '../correlationIdMiddleware';
+
+function getHeaders(init?: RequestInit): HeadersInit | undefined {
+  const correlationId = getCorrelationId();
+  if (!correlationId) return init?.headers;
+
+  return {
+    ...init?.headers,
+    'x-correlation-id': correlationId,
+  };
+}
+
+export function ndlaFetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+  const headers = getHeaders(init);
+  const newInit: RequestInit = { ...init, headers };
+
+  return fetch(input, newInit);
+}

--- a/src/api/oembedProxyApi.ts
+++ b/src/api/oembedProxyApi.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import fetch from 'isomorphic-fetch';
 import queryString from 'query-string';
 import {
   apiResourceUrl,
@@ -16,6 +15,7 @@ import {
 import { OembedEmbedData } from '../plugins/externalPlugin';
 import { H5pEmbedData } from '../plugins/h5pPlugin';
 import { PlainEmbed } from '../interfaces';
+import { ndlaFetch } from './ndlaFetch';
 
 export interface OembedProxyResponse {
   type: string;
@@ -50,7 +50,7 @@ export const fetchOembed = async (
     url.protocol = 'https:';
     newUrl = url.href;
   }
-  const response = await fetch(
+  const response = await ndlaFetch(
     apiResourceUrl(
       `/oembed-proxy/v1/oembed?${queryString.stringify({
         url: newUrl || embed.data.url,

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -6,13 +6,13 @@
  *
  */
 
-import fetch from 'isomorphic-fetch';
 import {
   apiResourceUrl,
   resolveJsonOrRejectWithError,
   headerWithAccessToken,
 } from '../utils/apiHelpers';
 import { ApiOptions } from '../interfaces';
+import { ndlaFetch } from './ndlaFetch';
 
 const baseUrl = apiResourceUrl(`/taxonomy/v1/`);
 
@@ -54,7 +54,7 @@ async function queryResources(
 ): Promise<TaxonomyResourceQuery[]> {
   const versionHeader = apiOptions.versionHash ? { VersionHash: apiOptions.versionHash } : null;
   const headers = { ...headerWithAccessToken(apiOptions.accessToken), ...versionHeader };
-  const response = await fetch(
+  const response = await ndlaFetch(
     `${baseUrl}resources?contentURI=urn:${contentType}:${contentId}&language=${apiOptions.lang}`,
     {
       headers,
@@ -70,7 +70,7 @@ async function queryTopics(
 ): Promise<TaxonomyTopicQuery[]> {
   const versionHeader = apiOptions.versionHash ? { VersionHash: apiOptions.versionHash } : null;
   const headers = { ...headerWithAccessToken(apiOptions.accessToken), ...versionHeader };
-  const response = await fetch(
+  const response = await ndlaFetch(
     `${baseUrl}topics?contentURI=urn:${contentType}:${contentId}&language=${apiOptions.lang}`,
     {
       headers,

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import cors from 'cors';
 import setup from './routes';
 import swaggerDefinition from './swagger/swaggerDefinition';
 import swaggerRoutes from './swagger/swaggerRoutes';
+import loggerMiddleware from './loggerMiddleware';
 
 // Swagger settings
 const swaggerOptions = {
@@ -50,6 +51,8 @@ app.use(
     credentials: true,
   }),
 );
+
+app.use(loggerMiddleware);
 
 setup(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import setup from './routes';
 import swaggerDefinition from './swagger/swaggerDefinition';
 import swaggerRoutes from './swagger/swaggerRoutes';
 import loggerMiddleware from './loggerMiddleware';
+import correlationIdMiddleware from './correlationIdMiddleware';
 
 // Swagger settings
 const swaggerOptions = {
@@ -52,6 +53,7 @@ app.use(
   }),
 );
 
+app.use(correlationIdMiddleware);
 app.use(loggerMiddleware);
 
 setup(app);

--- a/src/correlationIdMiddleware.ts
+++ b/src/correlationIdMiddleware.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { uuid } from '@ndla/util';
+import { NextFunction, Request, Response } from 'express';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { getAsString } from './routes';
+
+const asyncLocalStorage = new AsyncLocalStorage<string>();
+
+const correlationIdMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  const fromReq = getAsString(req.headers['x-correlation-id']);
+  const cid = !!fromReq ? fromReq : uuid();
+
+  asyncLocalStorage.run(cid, () => {
+    res.locals.correlationId = cid;
+    next();
+  });
+};
+
+export function getCorrelationId(): string | undefined {
+  return asyncLocalStorage.getStore();
+}
+
+export default correlationIdMiddleware;

--- a/src/loggerMiddleware.ts
+++ b/src/loggerMiddleware.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { uuid } from '@ndla/util';
+import { NextFunction, Request, Response } from 'express';
+import bunyan from 'bunyan';
+import { getAsString } from './routes';
+import { loggerStorage } from './utils/logger';
+
+export function setupLogger(correlationId: string, next: NextFunction): void {
+  loggerStorage.run(
+    bunyan.createLogger({
+      name: 'article-converter',
+      correlationId,
+    }),
+    () => {
+      next();
+    },
+  );
+}
+
+const loggerMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  const fromReq = getAsString(req.headers['x-correlation-id']);
+  const cid = !!fromReq ? fromReq : uuid();
+
+  setupLogger(cid, next);
+};
+
+export default loggerMiddleware;

--- a/src/loggerMiddleware.ts
+++ b/src/loggerMiddleware.ts
@@ -6,10 +6,8 @@
  *
  */
 
-import { uuid } from '@ndla/util';
 import { NextFunction, Request, Response } from 'express';
 import bunyan from 'bunyan';
-import { getAsString } from './routes';
 import { loggerStorage } from './utils/logger';
 
 export function setupLogger(correlationId: string, next: NextFunction): void {
@@ -18,16 +16,12 @@ export function setupLogger(correlationId: string, next: NextFunction): void {
       name: 'article-converter',
       correlationId,
     }),
-    () => {
-      next();
-    },
+    next,
   );
 }
 
 const loggerMiddleware = (req: Request, res: Response, next: NextFunction): void => {
-  const fromReq = getAsString(req.headers['x-correlation-id']);
-  const cid = !!fromReq ? fromReq : uuid();
-
+  const cid = res.locals.correlationId as string;
   setupLogger(cid, next);
 };
 

--- a/src/plugins/__tests__/conceptPlugin-test.js
+++ b/src/plugins/__tests__/conceptPlugin-test.js
@@ -8,10 +8,11 @@
 
 import nock from 'nock';
 import bunyan from 'bunyan';
-import log from '../../utils/logger';
+import getLogger from '../../utils/logger';
 import createConceptPlugin from '../conceptPlugin';
 
 test('fetch concept and draft concept', async () => {
+  const log = getLogger();
   log.level(bunyan.FATAL + 1); // temporarily disable logging
 
   let conceptPlugin = createConceptPlugin();

--- a/src/plugins/__tests__/contentLinkPlugin-test.js
+++ b/src/plugins/__tests__/contentLinkPlugin-test.js
@@ -8,7 +8,7 @@
 
 import nock from 'nock';
 import bunyan from 'bunyan';
-import log from '../../utils/logger';
+import getLogger from '../../utils/logger';
 import createContentLinkPlugin from '../contentLinkPlugin';
 
 const articleResource = [
@@ -127,6 +127,7 @@ test('fetchResource with missing taxonomy data should fallback to path without t
 });
 
 test('fetchResource where taxonomy fails should fallback to path without taxonomy', async () => {
+  const log = getLogger();
   log.level(bunyan.FATAL + 1); // temporarily disable logging
 
   const contentLinkPlugin = createContentLinkPlugin();

--- a/src/plugins/__tests__/relatedContentPlugin-test.js
+++ b/src/plugins/__tests__/relatedContentPlugin-test.js
@@ -8,7 +8,7 @@
 
 import nock from 'nock';
 import bunyan from 'bunyan';
-import log from '../../utils/logger';
+import getLogger from '../../utils/logger';
 import createRelatedContentPlugin from '../relatedContentPlugin';
 
 const articleResource = [
@@ -105,6 +105,7 @@ test('fetchResource for different taxonomy version', async () => {
 });
 
 test('fetchResource for an external article', async () => {
+  const log = getLogger();
   log.level(bunyan.FATAL + 1); // temporarily disable logging
 
   const relatedContentPlugin = createRelatedContentPlugin();
@@ -128,6 +129,7 @@ test('fetchResource for an external article', async () => {
 });
 
 test('fetchResource for two related articles, where one could not be fetched from article-api', async () => {
+  const log = getLogger();
   log.level(bunyan.FATAL + 1); // temporarily disable logging
 
   const relatedContentPlugin = createRelatedContentPlugin();
@@ -174,6 +176,7 @@ test('fetchResource for two related articles, where one could not be fetched fro
 });
 
 test('fetchResource for two related articles, where one could not be fetched from taxonomy-api', async () => {
+  const log = getLogger();
   log.level(bunyan.FATAL + 1); // temporarily disable logging
 
   const relatedContentPlugin = createRelatedContentPlugin();

--- a/src/plugins/contentLinkPlugin.tsx
+++ b/src/plugins/contentLinkPlugin.tsx
@@ -7,7 +7,7 @@
  */
 
 import { fetchArticleResource } from '../api/taxonomyApi';
-import log from '../utils/logger';
+import getLogger from '../utils/logger';
 import config from '../config';
 import { Plugin, Embed, ApiOptions, TransformOptions, PlainEmbed } from '../interfaces';
 
@@ -52,7 +52,7 @@ export default function createContentLinkPlugin(options: TransformOptions = {}):
       }
       return { ...embed, path };
     } catch (error) {
-      log.error(error);
+      getLogger().error(error);
       return {
         ...embed,
         path,

--- a/src/plugins/relatedContentPlugin.tsx
+++ b/src/plugins/relatedContentPlugin.tsx
@@ -15,7 +15,7 @@ import { ContentTypeBadge } from '@ndla/ui';
 import { constants } from '@ndla/ui';
 import { isObject } from 'lodash/fp';
 import { IArticleV2 } from '@ndla/types-article-api';
-import log from '../utils/logger';
+import getLogger from '../utils/logger';
 import { fetchArticle } from '../api/articleApi';
 import { ArticleResource, fetchArticleResource } from '../api/taxonomyApi';
 import config from '../config';
@@ -147,7 +147,7 @@ export default function createRelatedContentPlugin(
           article: article ? { ...article, resource } : undefined,
         };
       } catch (error) {
-        log.error(error);
+        getLogger().error(error);
         return embed;
       }
     }

--- a/src/replacer.ts
+++ b/src/replacer.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import log from './utils/logger';
+import getLogger from './utils/logger';
 import t from './locale/i18n';
 import { AnyEmbed, LocaleType, AnyPlugin, ResponseHeaders } from './interfaces';
 import { findPlugin } from './utils/findPlugin';
@@ -40,7 +40,7 @@ export async function replaceEmbedsInHtml(
     } else if (embed.embed.attr('data-resource') === 'file') {
       // do nothing
     } else {
-      log.warn(`Do not create markup for unknown embed '${embed.data.resource}'`);
+      getLogger().warn(`Do not create markup for unknown embed '${embed.data.resource}'`);
     }
   });
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -13,10 +13,10 @@ import { htmlTemplate, htmlErrorTemplate } from './utils/htmlTemplates';
 import { getHtmlLang } from './locale/configureLocale';
 import { getAppropriateErrorResponse } from './utils/errorHelpers';
 import config from './config';
-import log from './utils/logger';
+import getLogger from './utils/logger';
 import { ResponseHeaders } from './interfaces';
 
-const getAsString = (value: any): string => {
+export const getAsString = (value: any): string => {
   return typeof value === 'string' ? value : '';
 };
 
@@ -41,7 +41,7 @@ const setup = function routes(app: Express) {
         });
       })
       .catch((error) => {
-        log.error(error);
+        getLogger().error(error);
         const response = getAppropriateErrorResponse(error, config.isProduction);
         res.status(response.status).json(response);
       });
@@ -80,7 +80,7 @@ const setup = function routes(app: Express) {
         res.json(article);
       })
       .catch((error) => {
-        log.error(error);
+        getLogger().error(error);
         const response = getAppropriateErrorResponse(error, config.isProduction);
         res.status(response.status).json(response);
       });
@@ -114,7 +114,7 @@ const setup = function routes(app: Express) {
         res.end();
       })
       .catch((error) => {
-        log.error(error);
+        getLogger().error(error);
         const response = getAppropriateErrorResponse(error, config.isProduction);
         const rp = htmlErrorTemplate(lang, response);
         res.status(response.status).send(rp);
@@ -122,6 +122,7 @@ const setup = function routes(app: Express) {
   });
 
   app.post('/article-converter/json/:lang/transform-article', (req, res) => {
+    const log = getLogger();
     const body = req.body;
     const lang = getHtmlLang(req.params.lang ?? '');
     const draftConcept = req.query.draftConcept === 'true';

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -6,9 +6,10 @@
  *
  */
 
+import Logger from 'bunyan';
 import config from '../config';
 import { createErrorPayload } from './errorHelpers';
-import log from './logger';
+import getLogger from './logger';
 
 const NDLA_API_URL = config.ndlaApiUrl;
 
@@ -29,8 +30,8 @@ export function apiResourceUrl(path: string) {
   return apiBaseUrl + path;
 }
 
-export function rejectWithError(json: any, res: Response) {
-  log.logAndReturnValue('warn', 'JSON response from failed api call: ', json);
+export function rejectWithError(log: Logger, json: any, res: Response) {
+  log.warn('JSON response from failed api call:', json);
   return createErrorPayload(res.status, json.message ?? res.statusText, json);
 }
 
@@ -41,9 +42,10 @@ export async function resolveJsonOrRejectWithError<T>(res: Response): Promise<T>
   if (res.status === 404) {
     throw createErrorPayload(res.status, res.statusText);
   }
+  const log = getLogger();
   log.warn(`Api call to ${res.url} failed with status ${res.status} ${res.statusText}`);
   const json = await res.json();
-  throw rejectWithError(json, res);
+  throw rejectWithError(log, json, res);
 }
 
 export function headerWithAccessToken(accessToken: string) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,14 +1,26 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import bunyan from 'bunyan';
+import Logger from 'bunyan';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
-let log: any;
+export const loggerStorage = new AsyncLocalStorage<Logger>();
 
-if (!log) {
-  log = bunyan.createLogger({ name: 'article-converter' });
+const baseLogger = bunyan.createLogger({ name: 'article-converter' });
+
+export function getLogger(): Logger {
+  const storedLogger = loggerStorage.getStore();
+  if (!storedLogger) {
+    return baseLogger;
+  }
+
+  return storedLogger;
 }
 
-log.logAndReturnValue = (level: any, msg: any, value: any) => {
-  log[level](msg, value);
-  return value;
-};
-
-export default log;
+export default getLogger;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2456,6 +2456,11 @@
   version "9.4.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.7.tgz#57d81cd98719df2c9de118f2d5f3b1120dcd7275"
 
+"@types/node@^14.18.28":
+  version "14.18.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.28.tgz#ddb82da2fff476a8e827e8773c84c19d9c235278"
+  integrity sha512-CK2fnrQlIgKlCV3N2kM+Gznb5USlwA1KFX3rJVHmgVk6NJxFPuQ86pAcvKnu37IA4BGlSRz7sEE1lHL1aLZ/eQ==
+
 "@types/prettier@^2.1.5":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/1913

Legger til støtte for mottak og videresending av `correlationId`.

Kan testes ved å sjekke at `correlationId` logges og videresendes. Må fungere med både en tilsent ved `X-Correlation-ID` og generert dersom headeren ikke er tilstede. :smile:

Bumper node versjon til 14.20 for å få tilgang på `AsyncLocalStorage` modulen i node :^)