### PR TITLE
If no concept found, just display embed text to avoid empty modal

### DIFF
--- a/src/plugins/conceptPlugin.tsx
+++ b/src/plugins/conceptPlugin.tsx
@@ -17,7 +17,6 @@ import { Remarkable } from 'remarkable';
 import { fetchConcept } from '../api/conceptApi';
 import config from '../config';
 import { ApiOptions, Embed, LocaleType, PlainEmbed, Plugin, TransformOptions } from '../interfaces';
-import t from '../locale/i18n';
 import { ConceptBlock, transformVisualElement } from '../utils/conceptHelpers';
 import { render } from '../utils/render';
 

--- a/src/plugins/conceptPlugin.tsx
+++ b/src/plugins/conceptPlugin.tsx
@@ -153,22 +153,9 @@ export default function createConceptPlugin(options: TransformOptions = {}): Con
   };
 
   const onError = (embed: ConceptEmbed, locale: LocaleType) => {
-    const { contentId, linkText } = embed.data;
-
-    const children = typeof linkText === 'string' ? linkText : undefined;
-    return render(
-      <Notion
-        id={`notion_id_${contentId}`}
-        title={t(locale, 'concept.error.title')}
-        content={
-          <NotionDialogContent>
-            <NotionDialogText>{t(locale, 'concept.error.content')}</NotionDialogText>
-          </NotionDialogContent>
-        }>
-        {children}
-      </Notion>,
-      locale,
-    );
+    // Concept not found, just display the text
+    const { linkText } = embed.data;
+    return linkText;
   };
 
   const embedToHTML = async (embed: TransformedConceptEmbedType, locale: LocaleType) => {


### PR DESCRIPTION
Fixes NDLANO/Issues#3304

Dersom forklaring ikkje finnes gir det ingen meining i å vise en dialog med feilmelding. Bedre å berre vise teksten fra embedden slik at det ikkje ser ut som om det var en forklaring der.