### PR TITLE
Use react-html-parser for markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "he": "^1.2.0",
+    "html-react-parser": "^0.14.1",
     "http-status": "^1.3.1",
     "i18next": "20.3.5",
     "isomorphic-fetch": "^3.0.0",

--- a/src/plugins/conceptPlugin.tsx
+++ b/src/plugins/conceptPlugin.tsx
@@ -53,7 +53,7 @@ export interface ConceptMetaData {
 const renderMarkdown = (text: string) => {
   const md = new Remarkable();
   md.inline.ruler.enable(['sub', 'sup']);
-  return md.render(text);
+  return parse(md.render(text));
 };
 
 const renderInline = (
@@ -81,13 +81,11 @@ const renderInline = (
         <>
           <NotionDialogContent>
             {transformedHTML && <StyledDiv dangerouslySetInnerHTML={{ __html: transformedHTML }} />}
-            <NotionDialogText>
-              {parse(renderMarkdown(concept.content?.content ?? ''))}
-            </NotionDialogText>
+            <NotionDialogText>{renderMarkdown(concept.content?.content ?? '')}</NotionDialogText>
           </NotionDialogContent>
           <NotionDialogLicenses
             license={license}
-            source={parse(renderMarkdown(source))}
+            source={renderMarkdown(source)}
             authors={authors}
           />
         </>

--- a/src/plugins/conceptPlugin.tsx
+++ b/src/plugins/conceptPlugin.tsx
@@ -14,6 +14,7 @@ import cheerio from 'cheerio';
 import { uniqueId } from 'lodash';
 import React from 'react';
 import { Remarkable } from 'remarkable';
+import parse from 'html-react-parser';
 import { fetchConcept } from '../api/conceptApi';
 import config from '../config';
 import { ApiOptions, Embed, LocaleType, PlainEmbed, Plugin, TransformOptions } from '../interfaces';
@@ -52,8 +53,7 @@ export interface ConceptMetaData {
 const renderMarkdown = (text: string) => {
   const md = new Remarkable();
   md.inline.ruler.enable(['sub', 'sup']);
-  const rendered = md.render(text);
-  return <span dangerouslySetInnerHTML={{ __html: rendered }} />;
+  return md.render(text);
 };
 
 const renderInline = (
@@ -81,7 +81,9 @@ const renderInline = (
         <>
           <NotionDialogContent>
             {transformedHTML && <StyledDiv dangerouslySetInnerHTML={{ __html: transformedHTML }} />}
-            <NotionDialogText>{renderMarkdown(concept.content?.content ?? '')}</NotionDialogText>
+            <NotionDialogText>
+              {parse(renderMarkdown(concept.content?.content ?? ''))}
+            </NotionDialogText>
           </NotionDialogContent>
           <NotionDialogLicenses
             license={license}

--- a/src/plugins/conceptPlugin.tsx
+++ b/src/plugins/conceptPlugin.tsx
@@ -87,7 +87,7 @@ const renderInline = (
           </NotionDialogContent>
           <NotionDialogLicenses
             license={license}
-            source={renderMarkdown(source)}
+            source={parse(renderMarkdown(source))}
             authors={authors}
           />
         </>


### PR DESCRIPTION
Skriver om markdown i inline forklaring til å bruke `parse` fra `html-react-parser` i stedet for dangerouslyInsertHTML. 

Hvordan teste:
1. Kjør opp med lokal graphql og ndla-frontend
2. Åpne /articles/31466
3. Klikk på inline forklaring øverst
4. Se at markdown i innhold og i lenke på bunnen av modalen rendres korrekt.

<details>
<summary>
bilde
</summary>

![image](https://user-images.githubusercontent.com/17144211/204359731-15c4d15d-554c-4e5c-ab9d-6bc351c89df8.png)

</details>



Har rigget klar denne artikkelen for dette: https://test.ndla.no/article/31466.